### PR TITLE
Add mcpName for MCP Registry publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
-    }
+    },
+    "mcpName": "io.github.adi-singh13/agentmail"
 }


### PR DESCRIPTION
Adds the `mcpName` field to package.json as required by the official MCP Registry (registry.modelcontextprotocol.io).

This field is needed to publish the AgentMail MCP server to the registry so Claude Code, Cursor, and other MCP clients can discover it.

Once merged and the NPM package is republished with this field, we can register at: https://registry.modelcontextprotocol.io

Registry publish command ready to go after merge.