### PR TITLE
Improve repo presence: tools table, quick example, links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 
 .env
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentMail MCP Server
 
-The AgentMail MCP Server provides tools for the AgentMail API.
+Give your AI agent its own email address. MCP server for [AgentMail](https://agentmail.to).
 
 ## Setup
 
@@ -24,6 +24,44 @@ Get your API key from [AgentMail](https://agentmail.to)
 }
 ```
 
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_inbox` | Create a new email inbox for an agent |
+| `list_inboxes` | List all inboxes in your account |
+| `get_inbox` | Get details of a specific inbox |
+| `delete_inbox` | Delete an inbox |
+| `send_message` | Send an email from an agent inbox |
+| `reply_to_message` | Reply to an email in a thread |
+| `forward_message` | Forward an email |
+| `update_message` | Update message labels or status |
+| `list_threads` | List email threads in an inbox |
+| `get_thread` | Get a full email thread with messages |
+| `get_attachment` | Download an email attachment |
+
+## Quick Example
+
+Create an inbox for your agent and send an email — in 10 lines:
+
+```python
+from agentmail import AgentMailClient
+
+client = AgentMailClient(api_key="YOUR_API_KEY")
+
+# Create a dedicated inbox for your agent
+inbox = client.create_inbox(display_name="Sales Agent")
+print(f"Agent email: {inbox.inbox_id}")
+
+# Send an email
+client.send_message(
+    inbox_id=inbox.inbox_id,
+    to="prospect@example.com",
+    subject="Following up on our conversation",
+    text="Hi, I wanted to follow up on our earlier discussion..."
+)
+```
+
 ## Tool Selection
 
 By default, all available tools are loaded. You can selectively enable specific tools using the `--tools` argument with a comma-separated list of tool names.
@@ -35,7 +73,7 @@ By default, all available tools are loaded. You can selectively enable specific 
     "mcpServers": {
         "AgentMail": {
             "command": "npx",
-            "args": ["-y", "agentmail-mcp", "--tools", "get_message,send_message,reply_to_message"],
+            "args": ["-y", "agentmail-mcp", "--tools", "create_inbox,send_message,reply_to_message,list_threads,get_thread"],
             "env": {
                 "AGENTMAIL_API_KEY": "YOUR_API_KEY"
             }
@@ -43,3 +81,9 @@ By default, all available tools are loaded. You can selectively enable specific 
     }
 }
 ```
+
+## Links
+
+- [AgentMail](https://agentmail.to) — Email infrastructure for AI agents
+- [Documentation](https://docs.agentmail.to) — Full API reference
+- [Python SDK](https://github.com/agentmail-to/agentmail-python) — Python client library


### PR DESCRIPTION
## What this PR does

Updates the README to make the repo more discoverable and useful for developers browsing GitHub/MCP registries.

### Changes
- **Tools section** — Lists all 11 available MCP tools with descriptions. Registries like Glama pull from README to populate their listings.
- **Quick example** — 10 lines showing inbox creation + sending an email. Converts developers who are on the fence.
- **Links section** — One-click to docs, SDK, and main site.
- **Updated intro** — Clear one-liner: "Give your AI agent its own email address."

### Still needs (repo settings, not PR):
1. **Set repo description** → "Give your AI agent its own email address. MCP server for AgentMail."
2. **Set website URL** → agentmail.to
3. **Add topics** → mcp, model-context-protocol, ai-agents, email, agentmail
4. **All 3 founders Watch the repo** → Zero watchers looks abandoned
5. **Cut a v1.0.0 release** after merging → 6 production deployments but zero releases looks experimental. Gets surfaced in "recently released" on MCP registries.