### PR TITLE
fix: use package version for server metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+
 import { AgentMailClient } from 'agentmail'
 import { AgentMailToolkit } from 'agentmail-toolkit/mcp'
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+
+const packageJson = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string }
 
 const parseToolsArg = () => {
     const args = process.argv.slice(2)
@@ -27,7 +33,10 @@ const main = async () => {
     const client = new AgentMailClient({ baseUrl })
     const toolkit = new AgentMailToolkit(client)
 
-    const server = new McpServer({ name: 'AgentMail', version: '0.1.0' })
+    const server = new McpServer({
+        name: 'AgentMail',
+        version: packageJson.version,
+    })
     const transport = new StdioServerTransport()
 
     for (const tool of toolkit.getTools(toolNames)) server.registerTool(tool.name, tool, tool.callback)


### PR DESCRIPTION
## Summary
- read `package.json` from the built entrypoint
- use the package version for `McpServer` metadata instead of the stale `0.1.0` literal

Fixes #14

## Test plan
- `pnpm install --frozen-lockfile --ignore-workspace`
- `pnpm build`
- `pnpm lint`
- `rg "0\.1\.0|packageJson|package\.json|version" build/index.js src/index.ts package.json -n`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the `package.json` version for `McpServer` metadata so the server reports the correct version instead of the hardcoded "0.1.0" (fixes #14). Reads `package.json` from the built entrypoint and sets `version` at runtime.

<sup>Written for commit b076891660798730d67c1980fa9065c53dcbcf4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agentmail-to/agentmail-mcp/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

