### PR TITLE
Bump agentmail-toolkit to ^0.4.0 (24 tools), version 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-mcp",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "description": "AgentMail MCP Server",
     "scripts": {
         "build": "tsc && chmod 755 build/index.js",
@@ -30,8 +30,8 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.1",
-        "agentmail": "^0.4.10",
-        "agentmail-toolkit": "^0.2.7"
+        "agentmail": "^0.5.11",
+        "agentmail-toolkit": "^0.4.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^1.24.1
         version: 1.24.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       agentmail:
-        specifier: ^0.4.10
-        version: 0.4.10
+        specifier: ^0.5.11
+        version: 0.5.11
       agentmail-toolkit:
-        specifier: ^0.2.7
-        version: 0.2.7(@modelcontextprotocol/sdk@1.24.1(@cfworker/json-schema@4.1.1)(zod@4.1.13))
+        specifier: ^0.4.0
+        version: 0.4.0(@modelcontextprotocol/sdk@1.24.1(@cfworker/json-schema@4.1.1)(zod@4.1.13))
     devDependencies:
       '@eslint/js':
         specifier: ^9.29.0
@@ -247,8 +247,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agentmail-toolkit@0.2.7:
-    resolution: {integrity: sha512-VxM6pBZp6OXS4rAJRCtkjFhzsomYWuMCsOF4KQl6+ee3vF8g+89ZrMLdBeADH2MTh10GvW5nUghbni8XkYz7RA==}
+  agentmail-toolkit@0.4.0:
+    resolution: {integrity: sha512-I+tfI3TDUFld+60XgFaryRrjy/JyVNNV69/cjWC6xtldarHqbCQ99Qnz5tVpAjwJNW0kI7lQFqMRKYL4EJ5A2Q==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.24.1
       ai: ^6.0.0-beta.150
@@ -264,8 +264,8 @@ packages:
       langchain:
         optional: true
 
-  agentmail@0.4.10:
-    resolution: {integrity: sha512-LXk2muMmXM58D5pSuDdGl2H2uoE72NEGTfPsJ1du4C53DRaxUL0yuA9tFInGvEm5E2MkdiG7Q3MMqjGHlj5vBw==}
+  agentmail@0.5.11:
+    resolution: {integrity: sha512-va5OoAmhlecOcn6vfXMN1mBc5r6KMqPtUC36K18Ra74DU5/LY/0ckT7ZM9VwVbDN7uPBNrL4a5aI1fLtH98hEg==}
     engines: {node: '>=18.0.0'}
 
   ajv-formats@3.0.1:
@@ -1002,8 +1002,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1265,9 +1265,9 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agentmail-toolkit@0.2.7(@modelcontextprotocol/sdk@1.24.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)):
+  agentmail-toolkit@0.4.0(@modelcontextprotocol/sdk@1.24.1(@cfworker/json-schema@4.1.1)(zod@4.1.13)):
     dependencies:
-      agentmail: 0.4.10
+      agentmail: 0.5.11
       jszip: 3.10.1
       unpdf: 1.4.0
       zod: 4.1.13
@@ -1278,9 +1278,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  agentmail@0.4.10:
+  agentmail@0.5.11:
     dependencies:
-      ws: 8.18.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2019,7 +2019,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
+  ws@8.21.0: {}
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
Brings the npx/stdio server up to the API-parity toolkit release (agentmail-to/agentmail-toolkit#39 + #40).

- `agentmail-toolkit ^0.2.7 → ^0.4.0` — npx users were resolving 0.2.x, which predates both the directory-compliance fixes (#38) and the 24-tool surface (#39)
- `agentmail ^0.4.10 → ^0.5.11`
- package version `0.2.2 → 0.3.0`

Verified: built and ran the stdio server against a live API key — `tools/list` returns 24 tools, new tools (`search_threads`, `auth_me`, …) present, `send_message` carries `destructiveHint: true`.

After merge: `npm publish` by an owner so `npx -y agentmail-mcp` picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)