### PR TITLE
Add deprecation banner: point to hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # AgentMail MCP Server
 
+> **Deprecated:** AgentMail now runs a hosted MCP server at [`https://mcp.agentmail.to/mcp`](https://mcp.agentmail.to/mcp) (see [docs](https://docs.agentmail.to/integrations/mcp)). This local stdio package is no longer maintained. New integrations should use the hosted endpoint:
+>
+> ```json
+> {
+>     "mcpServers": {
+>         "AgentMail": {
+>             "url": "https://mcp.agentmail.to/mcp?apiKey=YOUR_API_KEY"
+>         }
+>     }
+> }
+> ```
+
 The AgentMail MCP Server provides tools for the AgentMail API.
 
-## Setup
+## Legacy (local stdio) setup
 
 ### Credentials
 
@@ -24,11 +36,11 @@ Get your API key from [AgentMail](https://agentmail.to)
 }
 ```
 
-## Tool Selection
+### Tool Selection
 
 By default, all available tools are loaded. You can selectively enable specific tools using the `--tools` argument with a comma-separated list of tool names.
 
-### Example
+#### Example
 
 ```json
 {


### PR DESCRIPTION
## Summary
- This repo (`agentmail-mcp`) is the deprecated local stdio MCP package. Its README was the only stale surface for this repo.
- Added a deprecation blockquote at the top of README.md pointing to the current hosted MCP server (`https://mcp.agentmail.to/mcp`) and docs (`https://docs.agentmail.to/integrations/mcp`), with the hosted JSON client config.
- Kept the existing local npx setup instructions (including the `--tools` selection example, a real feature of this package) intact under a new "Legacy (local stdio) setup" heading rather than deleting them.

## Test plan
- [x] Re-grepped the working tree for `agentmail-mcp|mcp.agentmail.to|npx.*agentmail|smithery|17 tool` — only expected legacy references remain (package.json's own package name/repo URL, and the intentional legacy npx instructions).
- [x] Confirmed no bare `https://mcp.agentmail.to` without `/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)