### PR TITLE
chore: bump agentmail-toolkit to 0.5.1 (OpenAI unclear-arguments fix)

### DIFF
--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "server": "to.agentmail/agentmail",
   "endpoint": "https://mcp.agentmail.to/mcp",
-  "digest": "sha256:71c18f6cefb5a98fc7e941b8aed7e9c73dafb1854160e05317ba3f3ddfe8fd24",
+  "digest": "sha256:25908bd6aeeb5567547e34b0b336b41cff8eb68e67466e7082fedfe0d9d0cfa0",
   "tools": [
     {
       "name": "list_inboxes",
@@ -1911,7 +1911,7 @@
             }
           },
           "attachments": {
-            "description": "Attachments",
+            "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
               "type": "object",
@@ -1937,11 +1937,11 @@
                   "type": "string"
                 },
                 "content": {
-                  "description": "Base64 encoded content",
+                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
                   "type": "string"
                 },
                 "url": {
-                  "description": "URL",
+                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
                   "type": "string",
                   "format": "uri"
                 }
@@ -2043,7 +2043,7 @@
             }
           },
           "attachments": {
-            "description": "Attachments",
+            "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
               "type": "object",
@@ -2069,11 +2069,11 @@
                   "type": "string"
                 },
                 "content": {
-                  "description": "Base64 encoded content",
+                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
                   "type": "string"
                 },
                 "url": {
-                  "description": "URL",
+                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
                   "type": "string",
                   "format": "uri"
                 }
@@ -2085,25 +2085,25 @@
             "description": "ID of message"
           },
           "replyAll": {
-            "description": "Reply to all recipients",
+            "description": "Reply to all original recipients. Mutually exclusive with to, cc, and bcc — the API rejects the request if both are set",
             "type": "boolean"
           },
           "to": {
-            "description": "Override reply recipients",
+            "description": "Override reply recipients, replacing the default (the original sender). Omit to reply to the sender only. Cannot be combined with replyAll",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "cc": {
-            "description": "Override CC recipients",
+            "description": "Override CC recipients. Cannot be combined with replyAll",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "bcc": {
-            "description": "Override BCC recipients",
+            "description": "Override BCC recipients. Cannot be combined with replyAll",
             "type": "array",
             "items": {
               "type": "string"
@@ -2179,7 +2179,7 @@
             }
           },
           "attachments": {
-            "description": "Attachments",
+            "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
               "type": "object",
@@ -2205,11 +2205,11 @@
                   "type": "string"
                 },
                 "content": {
-                  "description": "Base64 encoded content",
+                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
                   "type": "string"
                 },
                 "url": {
-                  "description": "URL",
+                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
                   "type": "string",
                   "format": "uri"
                 }
@@ -2384,7 +2384,7 @@
             }
           },
           "attachments": {
-            "description": "Attachments",
+            "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
               "type": "object",
@@ -2410,11 +2410,11 @@
                   "type": "string"
                 },
                 "content": {
-                  "description": "Base64 encoded content",
+                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
                   "type": "string"
                 },
                 "url": {
-                  "description": "URL",
+                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
                   "type": "string",
                   "format": "uri"
                 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "@clerk/mcp-tools": "0.3.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "agentmail": "0.5.14",
-    "agentmail-toolkit": "0.5.0",
+    "agentmail-toolkit": "0.5.1",
     "cors": "2.8.5",
     "express": "5.2.1",
     "jose": "5.9.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 0.5.14
         version: 0.5.14
       agentmail-toolkit:
-        specifier: 0.5.0
-        version: 0.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+        specifier: 0.5.1
+        version: 0.5.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -174,8 +174,8 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  agentmail-toolkit@0.5.0:
-    resolution: {integrity: sha512-IHmYfL+mQPCia8pN/td7cNLJq+GnUDXHr0TvR1lbea5oYPGa8RknKp3a7O7o0M3LZQKKTSSEr07e0hrn/oNDBg==}
+  agentmail-toolkit@0.5.1:
+    resolution: {integrity: sha512-BHyDtgmXI8UnZDPsWICM3/SvBVZ0J+zxWWOTeUT+YP5d0bD98vXy7kaU2960ER11u9TfneqWpdbx88jzbd/M0g==}
     peerDependencies:
       '@mariozechner/pi-agent-core': ^0.50.1
       '@modelcontextprotocol/sdk': ^1.24.1
@@ -768,7 +768,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agentmail-toolkit@0.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)):
+  agentmail-toolkit@0.5.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)):
     dependencies:
       agentmail: 0.5.14
       jszip: 3.10.1


### PR DESCRIPTION
Consumes agentmail-toolkit 0.5.1 (agentmail-to/agentmail-toolkit#44): attachment content/url exclusivity and replyAll-vs-recipient-override now specified in tool schema descriptions, addressing OpenAI's "Unclear Arguments" rejection on send_message / reply_to_message / forward_message.

- Manifest regenerated — 8 occurrences of the new attachment wording
- Full suite passes (node contract/http tests, python bridge, bridge boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)