### PR TITLE
fix: contain malformed-auth crash (Jul 19) and SSE reconnect-storm heap exhaustion (Jul 21)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -329,13 +329,18 @@ type AuthSource =
     | { kind: 'apiKey'; apiKey: string }
     | { kind: 'none' }
 
+// Tool definitions are static metadata (name/description/schemas) — identical
+// for every request — so enumerate them once at module load. Previously each
+// incoming request built its own placeholder AgentMailClient + AgentMailToolkit
+// just to enumerate tools, and long-lived SSE connections retained that whole
+// per-request graph until close, which amplified the 2026-07-21 reconnect-storm
+// heap exhaustion. The real, per-auth client is still built inside the tool
+// callback at invocation time.
+const staticToolkit = new AgentMailToolkit(new AgentMailClient({ apiKey: 'placeholder' }))
+const STATIC_TOOLS = staticToolkit.getTools()
+
 export function createMcpServer(auth: AuthSource): McpServer {
     const server = new McpServer({ name: 'AgentMail', version: '1.0.0' })
-
-    // Build a placeholder client just so the toolkit can enumerate tools.
-    // We swap in a real client per tool call below.
-    const placeholderClient = new AgentMailClient({ apiKey: 'placeholder' })
-    const toolkit = new AgentMailToolkit(placeholderClient)
 
     const noAuthMessage = {
         content: [
@@ -349,7 +354,7 @@ export function createMcpServer(auth: AuthSource): McpServer {
         ],
     }
 
-    for (const tool of toolkit.getTools()) {
+    for (const tool of STATIC_TOOLS) {
         server.registerTool(tool.name, tool, async (args, extra) => {
             try {
                 let client: AgentMailClient
@@ -572,6 +577,19 @@ function extractApiKey(req: express.Request): string | undefined {
     return fromQuery || fromHeader || fromBearer || fromEnv
 }
 
+/**
+ * 401 challenge identical in shape to the one @clerk/mcp-tools sends for a
+ * missing Authorization header (status, WWW-Authenticate resource_metadata
+ * pointer, body), so OAuth clients re-enter the discovery flow the same way
+ * in both cases. URL composition mirrors getPRMUrl in @clerk/mcp-tools.
+ */
+function sendOAuthChallenge(req: express.Request, res: express.Response) {
+    const prmUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource${req.originalUrl}`
+    res.status(401)
+        .set({ 'WWW-Authenticate': `Bearer resource_metadata=${prmUrl}` })
+        .json({ error: 'Unauthorized' })
+}
+
 const authRouter: express.RequestHandler = async (req, res, next) => {
     const apiKey = extractApiKey(req)
     if (apiKey) {
@@ -581,38 +599,73 @@ const authRouter: express.RequestHandler = async (req, res, next) => {
 
     // No API key. If Clerk is configured, hand off to mcpAuthClerk for OAuth.
     if (CLERK_ENABLED) {
-        return mcpAuthClerk(req, res, (err) => {
-            if (err) return next(err)
-            // mcpAuthClerk (from @clerk/mcp-tools) validates the Bearer token
-            // as a Clerk OAuth access token and, on success, writes an MCP SDK
-            // AuthInfo object directly to req.auth, OVERWRITING the function
-            // set earlier by clerkMiddleware. The AuthInfo shape is:
-            //   { token, scopes, clientId, extra: { userId } }
-            // (see verifyClerkToken in @clerk/mcp-tools/dist/chunk-H4BXCCRK.js)
-            //
-            // IMPORTANT: do NOT use getAuth(req) from @clerk/express here —
-            // that helper calls req.auth(options) expecting a session-token
-            // getter function, but mcpAuthClerk has replaced req.auth with a
-            // plain object, so getAuth() throws "TypeError: req.auth is not
-            // a function". Read the userId directly from req.auth.extra.
-            const authInfo = (
-                req as unknown as { auth?: { token?: string; extra?: { userId?: string } } }
-            ).auth
-            const userId = authInfo?.extra?.userId
-            // Clerk's user:org:read scope puts the user's selected org in the
-            // access token's `org_id` claim. The @clerk/mcp-tools wrapper
-            // doesn't surface it, so we decode the raw token. Falls back to
-            // undefined if the claim is missing — see buildClientFromClerkUser
-            // for how that case is handled (single-org auto-pick vs multi-org
-            // strict reject).
-            const clerkOrgId = extractOrgIdFromClerkToken(authInfo?.token)
-            if (userId) {
-                req.authSource = { kind: 'clerk', clerkUserId: userId, clerkOrgId }
-            } else {
-                req.authSource = { kind: 'none' }
-            }
-            next()
-        })
+        // Reject malformed Authorization headers BEFORE mcpAuthClerk sees them.
+        // Its inner mcpAuth middleware throws ("Invalid authorization header
+        // value, expected Bearer <token>") when the header carries no token
+        // after the scheme — e.g. a bare "Authorization: Bearer". Crucially,
+        // mcpAuthClerk invokes that middleware as `(await mcpAuth(...))(req,
+        // res, next)` WITHOUT awaiting the resulting promise, so the rejection
+        // is detached from the chain Express 5 tracks: no try/catch or error
+        // middleware can reach it, it surfaces as a process-level unhandled
+        // rejection, and Node exits with code 1. That crash-looped production
+        // three times on 2026-07-19 (10:03/10:13/10:14 UTC). The guard mirrors
+        // mcpAuth's own parse (`header.split(' ')[1]` empty) so we 401 exactly
+        // the requests that would otherwise kill the process.
+        const authHeader = req.headers.authorization
+        if (authHeader && !authHeader.split(' ')[1]) {
+            // Don't log the header value: a token joined by non-space
+            // whitespace would land here and must not reach the logs.
+            console.warn('[auth] malformed Authorization header (no token after scheme), returning 401')
+            return sendOAuthChallenge(req, res)
+        }
+
+        try {
+            return await mcpAuthClerk(req, res, (err) => {
+                if (err) {
+                    // A failure inside the auth middleware is an auth failure:
+                    // challenge the client instead of bubbling a 500.
+                    console.error('[auth] mcpAuthClerk error:', err)
+                    if (!res.headersSent) sendOAuthChallenge(req, res)
+                    return
+                }
+                // mcpAuthClerk (from @clerk/mcp-tools) validates the Bearer token
+                // as a Clerk OAuth access token and, on success, writes an MCP SDK
+                // AuthInfo object directly to req.auth, OVERWRITING the function
+                // set earlier by clerkMiddleware. The AuthInfo shape is:
+                //   { token, scopes, clientId, extra: { userId } }
+                // (see verifyClerkToken in @clerk/mcp-tools/dist/chunk-H4BXCCRK.js)
+                //
+                // IMPORTANT: do NOT use getAuth(req) from @clerk/express here —
+                // that helper calls req.auth(options) expecting a session-token
+                // getter function, but mcpAuthClerk has replaced req.auth with a
+                // plain object, so getAuth() throws "TypeError: req.auth is not
+                // a function". Read the userId directly from req.auth.extra.
+                const authInfo = (
+                    req as unknown as { auth?: { token?: string; extra?: { userId?: string } } }
+                ).auth
+                const userId = authInfo?.extra?.userId
+                // Clerk's user:org:read scope puts the user's selected org in the
+                // access token's `org_id` claim. The @clerk/mcp-tools wrapper
+                // doesn't surface it, so we decode the raw token. Falls back to
+                // undefined if the claim is missing — see buildClientFromClerkUser
+                // for how that case is handled (single-org auto-pick vs multi-org
+                // strict reject).
+                const clerkOrgId = extractOrgIdFromClerkToken(authInfo?.token)
+                if (userId) {
+                    req.authSource = { kind: 'clerk', clerkUserId: userId, clerkOrgId }
+                } else {
+                    req.authSource = { kind: 'none' }
+                }
+                next()
+            })
+        } catch (error) {
+            // Errors thrown on the awaited part of mcpAuthClerk (rare; the
+            // detached-rejection path is handled by the guard above). Same
+            // policy: auth-layer failure → 401 challenge, never a crash.
+            console.error('[auth] mcpAuthClerk threw:', error)
+            if (!res.headersSent) sendOAuthChallenge(req, res)
+            return
+        }
     }
 
     // No API key, no Clerk. Tools will return the noAuthMessage when called.
@@ -773,6 +826,18 @@ function maskEnvVar(name: string): string {
     const safePrefix = /^(pk_|sk_|am_)/.test(firstChars) ? firstChars : '***'
     return `${name}: present (len=${val.length}, prefix=${safePrefix})`
 }
+
+// Last-resort containment. Node's default for an unhandled promise rejection
+// is to exit(1), which takes down every live SSE connection on the box and
+// triggers a client reconnect storm against the replacement process. The known
+// producer (bare-Bearer throw detached inside @clerk/mcp-tools — see
+// authRouter) is guarded above, but any future detached rejection should be
+// logged loudly and survived, not turn into a crash loop. The request that
+// caused it gets no response and times out client-side; that is strictly
+// better than dropping everyone.
+process.on('unhandledRejection', (reason) => {
+    console.error('[fatal-contained] unhandled promise rejection:', reason)
+})
 
 if (process.env.AGENTMAIL_MCP_NO_LISTEN !== '1') app.listen(PORT, () => {
     console.log(`AgentMail MCP server running on port ${PORT}`)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { SignJWT } from 'jose'
 import crypto from 'node:crypto'
+import v8 from 'node:v8'
 import { z } from 'zod'
 
 // ============================================================================
@@ -739,14 +740,39 @@ app.get('/.well-known/openai-apps-challenge', (_req, res) => {
     res.type('text/plain').send(OPENAI_APPS_CHALLENGE_TOKEN)
 })
 
+// Reject non-POST MCP methods before auth and before any per-request
+// allocation. This server is stateless (sessionIdGenerator: undefined) and
+// never initiates messages, so a standalone GET SSE stream can never carry an
+// event — yet the SDK transport accepts the GET and holds the stream open
+// indefinitely, pinning the whole per-request graph (a fresh McpServer with
+// every registered tool, the transport, req/res) until the client goes away.
+// That is what turned the 2026-07-21 reconnect storm (~962 SSE connects in
+// 54s, 326 in one 5s window) into heap exhaustion at the ~495 MB V8 limit.
+//
+// The Streamable HTTP spec explicitly allows a server that offers no SSE
+// stream to answer GET with 405 Method Not Allowed; clients then proceed
+// without a notification stream, which for this server changes nothing.
+// DELETE (session termination) is likewise meaningless with no sessions.
+// Mounted before authRouter so a storm of GETs is shed without spending a
+// Clerk token verification on each one; body shape matches the SDK's own
+// 405 (jsonrpc error -32000).
+const statelessMethodGuard: express.RequestHandler = (req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'DELETE') return next()
+    res.status(405)
+        .set('Allow', 'POST')
+        .json({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'Method Not Allowed: stateless server, POST only' },
+            id: null,
+        })
+}
+
 // MCP request handler. We don't use streamableHttpHandler here because it
 // pre-binds an MCP server; we want to construct ours per-request based on
-// the resolved auth source.
+// the resolved auth source. Only POST reaches this handler: text/html GETs
+// are redirected to the docs above, all other GETs and DELETEs get a 405
+// from statelessMethodGuard.
 const mcpHandler: express.RequestHandler = async (req, res) => {
-    if (req.method === 'GET' && req.headers.accept?.includes('text/html')) {
-        return res.redirect(302, DOCS_URL)
-    }
-
     try {
         const authSource = req.authSource ?? { kind: 'none' }
         const server = createMcpServer(authSource)
@@ -773,9 +799,10 @@ app.get(['/', '/mcp'], (req, res, next) => {
     res.redirect(302, DOCS_URL)
 })
 
-// MCP endpoints. authRouter runs first to decide OAuth vs API key.
-app.all('/mcp', authRouter, mcpHandler)
-app.all('/', authRouter, mcpHandler)
+// MCP endpoints. statelessMethodGuard sheds GET/DELETE, then authRouter
+// decides OAuth vs API key for the POSTs that remain.
+app.all('/mcp', statelessMethodGuard, authRouter, mcpHandler)
+app.all('/', statelessMethodGuard, authRouter, mcpHandler)
 
 // OAuth discovery metadata endpoints. Only mounted when Clerk is configured.
 if (CLERK_ENABLED) {
@@ -802,14 +829,73 @@ if (CLERK_ENABLED) {
 }
 
 app.get('/health', (_req, res) => {
+    const { heapUsed, rss } = process.memoryUsage()
     res.json({
         status: 'ok',
         clerk_enabled: CLERK_ENABLED,
         agentmail_api_url: AGENTMAIL_API_URL ?? '(SDK default)',
         mcp_public_url: MCP_PUBLIC_URL ?? '(not set, using Host header)',
         build_sha: process.env.BUILD_SHA ?? 'unknown',
+        heap: {
+            used_mb: Math.round(heapUsed / MB),
+            limit_mb: Math.round(HEAP_LIMIT_BYTES / MB),
+            rss_mb: Math.round(rss / MB),
+        },
     })
 })
+
+// ============================================================================
+// Heap pressure telemetry
+//
+// The 2026-07-21 crash aborted at ~467 MB retained after full GC against a
+// ~495 MB V8 heap limit, with no warning beforehand. This monitor gives the
+// gateway logs a leading indicator and (opt-in) a heap snapshot captured
+// while there is still headroom to analyze it.
+//
+//   - Every 30s, if heap used exceeds AGENTMAIL_HEAP_WARN_MB (default 350,
+//     capped at 75% of the actual V8 limit so small dev heaps still warn
+//     before dying), log used/limit/rss.
+//   - If AGENTMAIL_HEAP_SNAPSHOT=1, additionally write ONE heap snapshot per
+//     process lifetime the first time the threshold is crossed. Opt-in and
+//     one-shot because v8.writeHeapSnapshot blocks the event loop and
+//     temporarily needs about as much memory as the heap it captures — the
+//     threshold sits well below the limit precisely so the capture can
+//     succeed. The .heapsnapshot lands in the working directory (or
+//     AGENTMAIL_HEAP_SNAPSHOT_DIR) for Chrome DevTools.
+//
+// unref() so the timer never keeps a test process (or a draining worker)
+// alive.
+// ============================================================================
+
+const MB = 1024 * 1024
+const HEAP_LIMIT_BYTES = v8.getHeapStatistics().heap_size_limit
+const HEAP_WARN_BYTES = Math.min(
+    (parseInt(process.env.AGENTMAIL_HEAP_WARN_MB || '', 10) || 350) * MB,
+    HEAP_LIMIT_BYTES * 0.75
+)
+let heapSnapshotWritten = false
+
+setInterval(() => {
+    const { heapUsed, rss } = process.memoryUsage()
+    if (heapUsed < HEAP_WARN_BYTES) return
+    console.warn(
+        `[heap] pressure: used ${Math.round(heapUsed / MB)} MB of ${Math.round(
+            HEAP_LIMIT_BYTES / MB
+        )} MB limit (rss ${Math.round(rss / MB)} MB, warn threshold ${Math.round(HEAP_WARN_BYTES / MB)} MB)`
+    )
+    if (!heapSnapshotWritten && process.env.AGENTMAIL_HEAP_SNAPSHOT === '1') {
+        heapSnapshotWritten = true
+        try {
+            const dir = process.env.AGENTMAIL_HEAP_SNAPSHOT_DIR
+            const file = v8.writeHeapSnapshot(
+                dir ? `${dir.replace(/\/$/, '')}/agentmail-mcp-${Date.now()}.heapsnapshot` : undefined
+            )
+            console.warn(`[heap] snapshot written to ${file}`)
+        } catch (error) {
+            console.error('[heap] snapshot failed:', error)
+        }
+    }
+}, 30_000).unref()
 
 // ============================================================================
 // Env var diagnostic (prints on boot to help debug Manufact injection issues).

--- a/tests/server-auth.test.mjs
+++ b/tests/server-auth.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+process.env.AGENTMAIL_MCP_NO_LISTEN = '1'
+// Well-formed (but fake) Clerk keys so CLERK_ENABLED is true and the OAuth
+// auth path — where the 2026-07-19 bare-Bearer crash lived — is mounted.
+// The malformed-header guard rejects before any Clerk network call happens.
+process.env.CLERK_PUBLISHABLE_KEY = `pk_test_${Buffer.from('example.clerk.accounts.dev$').toString('base64')}`
+process.env.CLERK_SECRET_KEY = 'sk_test_auth_guard_regression'
+const { app } = await import('../packages/server/build/index.js')
+
+test('malformed Authorization headers get a 401 challenge instead of crashing the process', async (t) => {
+  const server = app.listen(0)
+  t.after(() => server.close())
+  await new Promise((resolve) => server.once('listening', resolve))
+  const { port } = server.address()
+
+  // Each of these made @clerk/mcp-tools throw on a detached promise, which
+  // exited Node with code 1 (Jul 19 incidents at 10:03/10:13/10:14 UTC).
+  for (const authorization of ['Bearer', 'bearer', 'not-a-bearer-header']) {
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        authorization,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
+    })
+    assert.equal(res.status, 401, `expected 401 for header ${JSON.stringify(authorization)}`)
+    assert.match(
+      res.headers.get('www-authenticate') ?? '',
+      /^Bearer resource_metadata=.*\/\.well-known\/oauth-protected-resource\/mcp$/,
+      'challenge must point clients back into OAuth discovery',
+    )
+    assert.deepEqual(await res.json(), { error: 'Unauthorized' })
+  }
+
+  // The server is still alive and serving after the malformed requests.
+  const health = await fetch(`http://127.0.0.1:${port}/health`)
+  assert.equal(health.status, 200)
+  assert.equal((await health.json()).clerk_enabled, true)
+})
+
+test('am_ API keys sent as Bearer tokens still route to the API-key path', async (t) => {
+  const server = app.listen(0)
+  t.after(() => server.close())
+  await new Promise((resolve) => server.once('listening', resolve))
+  const { port } = server.address()
+
+  // Sanity check that the guard sits behind extractApiKey: a well-formed
+  // am_ Bearer header must not be challenged with a 401.
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer am_test_key',
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
+  })
+  assert.equal(res.status, 200)
+})

--- a/tests/server-http.test.mjs
+++ b/tests/server-http.test.mjs
@@ -12,13 +12,17 @@ test('health identifies the build and human MCP navigation redirects before auth
   const { port } = server.address()
 
   const health = await fetch(`http://127.0.0.1:${port}/health`)
-  assert.deepEqual(await health.json(), {
+  const { heap, ...healthRest } = await health.json()
+  assert.deepEqual(healthRest, {
     status: 'ok',
     clerk_enabled: false,
     agentmail_api_url: '(SDK default)',
     mcp_public_url: '(not set, using Host header)',
     build_sha: 'test-sha',
   })
+  assert.ok(heap.used_mb > 0)
+  assert.ok(heap.limit_mb >= heap.used_mb)
+  assert.ok(heap.rss_mb > 0)
 
   const redirect = await fetch(`http://127.0.0.1:${port}/mcp`, {
     headers: { accept: 'text/html' },
@@ -26,4 +30,39 @@ test('health identifies the build and human MCP navigation redirects before auth
   })
   assert.equal(redirect.status, 302)
   assert.equal(redirect.headers.get('location'), 'https://docs.agentmail.to/integrations/mcp')
+})
+
+test('stateless server sheds GET SSE and DELETE with 405 before building any per-request state', async (t) => {
+  const server = app.listen(0)
+  t.after(() => server.close())
+  await new Promise((resolve) => server.once('listening', resolve))
+  const { port } = server.address()
+
+  // Before this guard, a GET with accept: text/event-stream opened a
+  // standalone SSE stream the SDK held open forever, pinning a full
+  // McpServer + transport graph per connection — the amplifier behind the
+  // Jul 21 reconnect-storm heap exhaustion.
+  for (const path of ['/', '/mcp']) {
+    for (const method of ['GET', 'DELETE']) {
+      const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+        method,
+        headers: { accept: 'application/json, text/event-stream' },
+      })
+      assert.equal(res.status, 405, `${method} ${path}`)
+      assert.equal(res.headers.get('allow'), 'POST')
+      const body = await res.json()
+      assert.equal(body.error.code, -32000)
+    }
+  }
+
+  // POST still works end to end.
+  const ping = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
+  })
+  assert.equal(ping.status, 200)
 })


### PR DESCRIPTION
Fixes both production crash classes from the Jul 19/21 incident report.

## 1. Malformed Authorization header → process exit (Jul 19, 10:03/10:13/10:14 UTC)

A bare `Authorization: Bearer` header made `@clerk/mcp-tools`' inner `mcpAuth` middleware throw `Invalid authorization header value, expected Bearer <token>, received Bearer` — and critically, `mcpAuthClerk` invokes that middleware as `(await mcpAuth(...))(req, res, next)` **without awaiting the resulting promise**. The rejection is therefore detached from the promise chain Express 5 tracks: no try/catch around `mcpAuthClerk` and no error middleware can reach it. It surfaces as a process-level unhandled rejection and Node exits with code 1.

- **Guard before `mcpAuthClerk`**: `authRouter` rejects any Authorization header with no token after the scheme (mirroring `mcpAuth`'s own parse) with a 401 whose `WWW-Authenticate: Bearer resource_metadata=...` challenge matches the missing-header case, so OAuth clients re-enter discovery identically. Because the library rejection is detached, pre-validation is the only viable containment.
- The awaited part of `mcpAuthClerk` and its error callback now answer a 401 challenge instead of bubbling a 500 or escaping.
- A `process.on('unhandledRejection')` log-and-survive backstop turns any future detached rejection into one wedged request instead of a crash loop that drops every live SSE connection.

## 2. SSE reconnect storm → heap exhaustion (Jul 21, 08:33 UTC)

Two compounding causes in the deployed code:

- **Standalone GET SSE streams pinned full request graphs.** This server is stateless (`sessionIdGenerator: undefined`) and never initiates messages, so a GET SSE stream can never carry an event — yet the SDK transport accepts the GET and holds the stream open indefinitely, retaining a fresh `McpServer` (every registered tool + schemas), transport, and req/res per connection. With ~962 SSE connects in the 54s before the abort (326 in one 5s window), those pinned graphs drove the heap into the ~495 MB limit. GET and DELETE on the MCP endpoints now answer **405 `Allow: POST` before auth runs**, so a storm is shed without allocating per-request state or spending a Clerk verification per connection. The Streamable HTTP spec explicitly permits 405 from servers that offer no SSE stream; clients proceed without a notification stream, which changes nothing for a server that never pushes. text/html GETs still redirect to the docs.
- **Per-request placeholder toolkit.** Tool definitions are static metadata, so they're now enumerated once at module load instead of constructing a placeholder `AgentMailClient` + `AgentMailToolkit` on every request. The real per-auth client is still built per tool invocation, unchanged.

Plus the report's observability recommendation: heap usage is logged every 30s once above `AGENTMAIL_HEAP_WARN_MB` (default 350 MB, capped at 75% of the real V8 limit), with an opt-in (`AGENTMAIL_HEAP_SNAPSHOT=1`) one-shot heap snapshot captured at that threshold — while there's still headroom for the capture to succeed. `/health` now reports `heap.used_mb` / `limit_mb` / `rss_mb` for gateway metrics.

## Tests

- `tests/server-auth.test.mjs` (Clerk enabled): `Bearer`, `bearer`, and a token-less non-Bearer header each get a 401 with the OAuth discovery challenge and the server keeps serving; an `am_` key sent as Bearer still routes to the API-key path. Verified against the pre-fix build: the malformed request never gets a response (the detached rejection), matching the production crash.
- `tests/server-http.test.mjs`: GET/DELETE get 405 on both `/` and `/mcp` while POST `ping` still serves 200; `/health` assertions updated for the heap block.
- Full suite green; `mcp-manifest.json` byte-identical (tool contract unchanged).

Deeper session-lifecycle rework is deliberately deferred to the stateless MCP spec migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvLxVwpE6aDxntUsvom8W2