### PR TITLE
fix: start npm bridge through bin symlinks

### DIFF
--- a/packages/npm-stdio-bridge/package.json
+++ b/packages/npm-stdio-bridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-mcp",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "stdio compatibility bridge for the hosted AgentMail MCP server",
     "keywords": [
         "agentmail",

--- a/packages/npm-stdio-bridge/src/index.ts
+++ b/packages/npm-stdio-bridge/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
@@ -15,10 +16,10 @@ import {
     type Progress,
 } from '@modelcontextprotocol/sdk/types.js'
 
-const VERSION = '1.0.0'
+const VERSION = '1.0.1'
 const ENDPOINT = new URL('https://mcp.agentmail.to/mcp')
-const BRIDGE_HEADER = 'node/1.0.0'
-const USER_AGENT = 'agentmail-mcp-node/1.0.0'
+const BRIDGE_HEADER = 'node/1.0.1'
+const USER_AGENT = 'agentmail-mcp-node/1.0.1'
 
 export function parseTools(args: string[]) {
     const index = args.indexOf('--tools')
@@ -99,7 +100,8 @@ async function main() {
     await startBridge(remote, new StdioServerTransport(), parseTools(process.argv.slice(2)))
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+const entryUrl = process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href
+if (entryUrl && import.meta.url === entryUrl) {
     main().catch((error) => {
         const message = error instanceof Error ? error.message : ''
         console.error(

--- a/packages/npm-stdio-bridge/test/artifact.test.mjs
+++ b/packages/npm-stdio-bridge/test/artifact.test.mjs
@@ -1,19 +1,22 @@
 import assert from 'node:assert/strict'
-import { readFile, stat } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, symlink } from 'node:fs/promises'
 import { execFileSync, spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 
-test('published artifact is an executable bridge without AgentMail implementation dependencies', async () => {
+test('published artifact is an executable bridge without AgentMail implementation dependencies', async (t) => {
     const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-    assert.equal(packageJson.version, '1.0.0')
+    assert.equal(packageJson.version, '1.0.1')
     assert.deepEqual(packageJson.dependencies, { '@modelcontextprotocol/sdk': '1.29.0' })
 
     const built = await readFile(new URL('../build/index.js', import.meta.url), 'utf8')
     assert.match(built, /^#!\/usr\/bin\/env node/)
     assert.match(built, /https:\/\/mcp\.agentmail\.to\/mcp/)
     assert.match(built, /X-AgentMail-MCP-Bridge/)
-    assert.match(built, /node\/1\.0\.0/)
-    assert.match(built, /agentmail-mcp-node\/1\.0\.0/)
+    assert.match(built, /node\/1\.0\.1/)
+    assert.match(built, /agentmail-mcp-node\/1\.0\.1/)
     assert.doesNotMatch(built, /agentmail-toolkit|from ['"]agentmail['"]|list_inboxes|send_message/)
     assert.ok((await stat(new URL('../build/index.js', import.meta.url))).mode & 0o111)
 
@@ -27,6 +30,15 @@ test('published artifact is an executable bridge without AgentMail implementatio
     assert.equal(launch.status, 1)
     assert.equal(launch.stdout, '')
     assert.match(launch.stderr, /AGENTMAIL_API_KEY is required/)
+
+    const temp = await mkdtemp(join(tmpdir(), 'agentmail-mcp-bin-'))
+    t.after(() => rm(temp, { recursive: true, force: true }))
+    const bin = join(temp, 'agentmail-mcp')
+    await symlink(fileURLToPath(new URL('../build/index.js', import.meta.url)), bin)
+    const symlinkLaunch = spawnSync(process.execPath, [bin], { env, encoding: 'utf8' })
+    assert.equal(symlinkLaunch.status, 1)
+    assert.equal(symlinkLaunch.stdout, '')
+    assert.match(symlinkLaunch.stderr, /AGENTMAIL_API_KEY is required/)
 
     const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
         cwd: new URL('..', import.meta.url),


### PR DESCRIPTION
Fixes #24. Related duplicate report: #25.

## Summary

- Resolve `process.argv[1]` to its real path before the ESM main-module comparison, so npm/npx bin symlinks start the bridge.
- Add a regression that launches the built bridge through a real symlink and requires the normal missing-key diagnostic instead of silent exit `0`.
- Bump the npm bridge to `1.0.1`, including its bridge and user-agent versions, so the immutable `1.0.0` release can be replaced by a patch release.

No dependency was added. The hosted server and Python bridge are unchanged.

## Verification

- `pnpm --filter agentmail-mcp test`
- `pnpm test`

Both pass locally. After manual merge, publishing `1.0.1` and smoke-testing a clean `npx -y agentmail-mcp@1.0.1` install remain manual release steps.

## CI note

The repository tests and contract check pass on GitHub. The combined job currently fails afterward at `pnpm audit --prod` because the unchanged lockfile contains newly reported `fast-uri@3.1.3` and `@hono/node-server@1.19.14` advisories. This PR changes no dependency or lockfile; that baseline dependency update is intentionally not mixed into this bridge fix.
