### PR TITLE
ci: separate deterministic checks from live drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,3 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
-      - run: pnpm check:contract
-      - run: pnpm audit --prod
-      - run: uv run --with build python/stdio-bridge/scripts/smoke-artifacts.sh

--- a/.github/workflows/public-surfaces.yml
+++ b/.github/workflows/public-surfaces.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   schedule:
     - cron: "17 15 * * 1"
+  workflow_dispatch:
 
 jobs:
   stale-references:
@@ -18,4 +19,13 @@ jobs:
       - run: python scripts/check-stale-references.py --self-test
       - run: python scripts/check-stale-references.py
       - run: python scripts/audit-public-surfaces.py --self-test
-      - run: python scripts/audit-public-surfaces.py
+
+  live-surfaces:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python scripts/audit-public-surfaces.py --strict

--- a/.github/workflows/python-artifact.yml
+++ b/.github/workflows/python-artifact.yml
@@ -1,0 +1,27 @@
+name: Smoke Python package
+
+on:
+  pull_request:
+    paths:
+      - python/stdio-bridge/**
+      - .github/workflows/python-artifact.yml
+  push:
+    branches: [main]
+    paths:
+      - python/stdio-bridge/**
+      - .github/workflows/python-artifact.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: 0.11.28
+          python-version: "3.12"
+      - run: uv run --with build python/stdio-bridge/scripts/smoke-artifacts.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,32 @@
+name: Audit production dependencies
+
+on:
+  pull_request:
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - packages/*/package.json
+      - .github/workflows/security.yml
+  push:
+    branches: [main]
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - packages/*/package.json
+      - .github/workflows/security.yml
+  schedule:
+    - cron: "47 15 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.4
+      - run: pnpm audit --prod --audit-level high

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "start": "pnpm --filter @agentmail/mcp-server start",
         "generate:manifest": "pnpm --filter @agentmail/mcp-server build && node scripts/generate-manifest.mjs",
         "check:bridges": "node scripts/check-bridge-boundaries.mjs",
-        "check:contract": "node scripts/check-contract.mjs",
+        "check:contract": "pnpm --filter @agentmail/mcp-server build && node scripts/check-contract.mjs",
         "test:python": "uv run --no-project --with ./python/stdio-bridge --with pytest pytest -q python/stdio-bridge/tests",
-        "test": "pnpm --filter agentmail-mcp test && pnpm generate:manifest && node --test tests/*.test.mjs && pnpm test:python && pnpm check:bridges"
+        "test": "pnpm check:contract && pnpm --filter agentmail-mcp test && node --test tests/*.test.mjs && pnpm test:python && pnpm check:bridges"
     },
     "devDependencies": {
         "@modelcontextprotocol/sdk": "1.29.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,8 +327,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -795,7 +795,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -926,7 +926,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   finalhandler@2.1.1:
     dependencies:

--- a/scripts/audit-public-surfaces.py
+++ b/scripts/audit-public-surfaces.py
@@ -44,6 +44,8 @@ def fetch(url: str) -> tuple[int, bytes]:
             return response.status, response.read()
     except urllib.error.HTTPError as exc:
         return exc.code, exc.read()
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return 0, str(exc).encode()
 
 
 def registry(name: str) -> dict:
@@ -59,8 +61,8 @@ def audit() -> list[str]:
     if endpoint_status not in {200, 401, 405}:
         problems.append(f"canonical endpoint returned HTTP {endpoint_status}")
 
-    for name, url in CONTROLLED.items():
-        status, body = fetch(url)
+    responses = {name: fetch(url) for name, url in CONTROLLED.items()}
+    for name, (status, body) in responses.items():
         text = body.decode("utf-8", "replace")
         if status != 200:
             problems.append(f"{name} returned HTTP {status}")
@@ -69,23 +71,31 @@ def audit() -> list[str]:
             if stale.lower() in text.lower():
                 problems.append(f"{name} contains stale reference: {stale}")
 
-    status, docs = fetch(CONTROLLED["MCP docs"])
+    status, docs = responses["MCP docs"]
     text = docs.decode("utf-8", "replace")
     if status != 200 or ENDPOINT not in text:
         problems.append("published MCP docs do not advertise the canonical endpoint")
     if SOURCE not in text:
         problems.append("published MCP docs do not advertise the canonical source")
 
-    canonical = registry("to.agentmail/agentmail")
-    entries = canonical.get("servers", [])
-    if len(entries) != 1:
-        problems.append("canonical Registry identity is missing or ambiguous")
-    elif entries[0]["server"].get("remotes", [{}])[0].get("url") != ENDPOINT:
-        problems.append("canonical Registry identity advertises a different endpoint")
+    try:
+        canonical = registry("to.agentmail/agentmail")
+    except RuntimeError as exc:
+        problems.append(str(exc))
+    else:
+        entries = canonical.get("servers", [])
+        if len(entries) != 1:
+            problems.append("canonical Registry identity is missing or ambiguous")
+        elif entries[0]["server"].get("remotes", [{}])[0].get("url") != ENDPOINT:
+            problems.append("canonical Registry identity advertises a different endpoint")
 
-    legacy = registry("ai.smithery/agentmail")
-    if any(item.get("_meta", {}).get("io.modelcontextprotocol.registry/official", {}).get("status") == "active" for item in legacy.get("servers", [])):
-        problems.append("legacy Smithery Registry identity is still active")
+    try:
+        legacy = registry("ai.smithery/agentmail")
+    except RuntimeError as exc:
+        problems.append(str(exc))
+    else:
+        if any(item.get("_meta", {}).get("io.modelcontextprotocol.registry/official", {}).get("status") == "active" for item in legacy.get("servers", [])):
+            problems.append("legacy Smithery Registry identity is still active")
     return problems
 
 


### PR DESCRIPTION
## Summary

- make `pnpm test` check the committed runtime manifest before any command can regenerate it
- keep `test` as the single deterministic always-on CI gate
- move production dependency auditing into a dependency-scoped weekly/manual workflow
- update `fast-uri` to the patched 3.1.4 release and fail the audit on high/critical findings
- move Python distribution smoke tests into a Python-package-scoped workflow
- keep local stale-reference checks on every pull request while moving flaky live network probes to strict weekly/manual runs
- report public-surface timeouts as audit findings instead of tracebacks

## Why

This preserves every meaningful detector while separating deterministic code checks from network drift monitoring. It also closes a real ordering bug where tests regenerated `mcp-manifest.json` before checking it, allowing a stale committed contract to pass CI.

The remaining moderate `@hono/node-server` advisory affects its Windows static-file helper. This bridge does not use that helper, and the available 2.x fix requires Node 20 while the published bridge supports Node 18, so this PR reports it without adding a risky transitive major override.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm audit --prod --audit-level high`
- `uv run --with build python/stdio-bridge/scripts/smoke-artifacts.sh`
- stale-reference and public-surface self-tests
- parsed every workflow as YAML

Draft only; do not merge automatically.
