### PR TITLE
Fix malformed Clerk tokens returning MCP 500s

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -703,6 +703,31 @@ function publicUrlOverride(req: express.Request, _res: express.Response, next: e
     next()
 }
 
+// Clerk's request middleware runs before authRouter because mcpAuthClerk relies
+// on the auth state it installs on req. Treat it as an untrusted-input boundary:
+// malformed JWT-shaped Bearer tokens can throw while Clerk decodes them, before
+// authRouter's own guards or error handling get a chance to run. Convert those
+// failures into the same 401 OAuth challenge as every other invalid credential
+// instead of letting Express's default handler expose a stack trace in an HTML
+// 500 response.
+//
+// AgentMail API keys must bypass Clerk entirely. Reusing extractApiKey here and
+// in authRouter keeps both layers' routing decisions identical.
+const clerkRequestMiddleware = CLERK_ENABLED ? clerkMiddleware() : undefined
+
+const clerkAuthBoundary: express.RequestHandler = (req, res, next) => {
+    if (!clerkRequestMiddleware || extractApiKey(req)) return next()
+
+    return clerkRequestMiddleware(req, res, (error?: unknown) => {
+        if (!error) return next()
+
+        const errorName = error instanceof Error ? error.name : 'UnknownError'
+        console.warn(`[auth] Clerk request authentication failed (${errorName}), returning 401`)
+        if (!res.headersSent) return sendOAuthChallenge(req, res)
+        next(error)
+    })
+}
+
 // ============================================================================
 // Express app
 // ============================================================================
@@ -717,13 +742,11 @@ export const app = express()
 app.set('trust proxy', true)
 
 // Normalize req.headers.host to MCP_PUBLIC_URL if set. Must run BEFORE cors
-// and clerkMiddleware so they see the normalized URL.
+// and the Clerk auth boundary so downstream auth sees the normalized URL.
 app.use(publicUrlOverride)
 
 app.use(cors({ exposedHeaders: ['WWW-Authenticate'] }))
-if (CLERK_ENABLED) {
-    app.use(clerkMiddleware())
-}
+app.use(clerkAuthBoundary)
 // Match the AgentMail API's inbound ceiling exactly. The API runs on API
 // Gateway v2 (HTTP API), whose max request body is a hard, non-configurable
 // 10 MB (agentmail-api infra/core/gateway.ts uses apigatewayv2.Api with no

--- a/tests/server-auth.test.mjs
+++ b/tests/server-auth.test.mjs
@@ -15,9 +15,18 @@ test('malformed Authorization headers get a 401 challenge instead of crashing th
   await new Promise((resolve) => server.once('listening', resolve))
   const { port } = server.address()
 
-  // Each of these made @clerk/mcp-tools throw on a detached promise, which
-  // exited Node with code 1 (Jul 19 incidents at 10:03/10:13/10:14 UTC).
-  for (const authorization of ['Bearer', 'bearer', 'not-a-bearer-header']) {
+  // Cover both the bare/malformed scheme shapes that reached
+  // @clerk/mcp-tools and JWT-shaped input that fails in the earlier global
+  // Clerk request middleware.
+  for (const authorization of [
+    'Bearer',
+    'bearer',
+    'not-a-bearer-header',
+    // A three-segment token gets past the bare-Bearer guard, then fails while
+    // the global Clerk middleware decodes its JWT payload. Production returned
+    // an HTML 500 for this shape instead of restarting OAuth.
+    'Bearer abc.def.ghi',
+  ]) {
     const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary

- wrap the global Clerk request middleware as an authentication boundary
- convert malformed JWT decode failures into the existing OAuth `401` challenge
- bypass Clerk request parsing for AgentMail `am_` API keys
- log only the authentication error type, without credentials or stack traces

## Production evidence

Manufact deployment #84 recorded 88 organic HTTP 500 responses in the inspected window. Every failure was an MCP `initialize` request from Claude.ai or Claude Code. Runtime logs showed Clerk JWT decoding failures such as `SyntaxError: Unexpected end of data` before `authRouter` ran.

A controlled `Bearer abc.def.ghi` request reproduced the same HTML 500 locally and against production. With this change, the request receives `401 Unauthorized` plus `WWW-Authenticate`, allowing the client to restart OAuth.

## Testing

- added regression coverage for a malformed three-segment JWT
- retained coverage for bare/malformed Authorization headers
- retained coverage for `am_` Bearer API-key routing
- `pnpm test` passes, including contract, TypeScript, Node, Python, and bridge checks

## Rollout check

After deployment, confirm malformed Clerk-token events return 401 and that Claude `initialize` 500s stop without affecting valid OAuth or AgentMail API-key traffic.