### PR TITLE
Minimize the hosted MCP approval surface

### DIFF
--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "server": "to.agentmail/agentmail",
   "endpoint": "https://mcp.agentmail.to/mcp",
-  "digest": "sha256:25908bd6aeeb5567547e34b0b336b41cff8eb68e67466e7082fedfe0d9d0cfa0",
+  "digest": "sha256:5234e99bcea8d93effdb02a5e50a3d60b0d0a92f6f264a467d9551dc25e1ccfa",
   "tools": [
     {
       "name": "list_inboxes",
@@ -58,26 +58,6 @@
                 "clientId": {
                   "type": "string"
                 },
-                "metadata": {
-                  "description": "Custom metadata attached to the inbox",
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
-                  }
-                },
                 "updatedAt": {
                   "type": "string",
                   "format": "date-time",
@@ -98,7 +78,7 @@
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -156,26 +136,6 @@
           "clientId": {
             "type": "string"
           },
-          "metadata": {
-            "description": "Custom metadata attached to the inbox",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
-            }
-          },
           "updatedAt": {
             "type": "string",
             "format": "date-time",
@@ -214,7 +174,7 @@
     {
       "name": "create_inbox",
       "title": "Create Inbox",
-      "description": "Create a new email inbox. Optionally specify username, domain, display name, and metadata.",
+      "description": "Create a new email inbox. Optionally specify username, domain, and display name.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -233,26 +193,6 @@
           "clientId": {
             "description": "Client-provided ID for idempotent creation",
             "type": "string"
-          },
-          "metadata": {
-            "description": "Custom metadata key-value pairs to attach to the inbox",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
-            }
           }
         },
         "$schema": "http://json-schema.org/draft-07/schema#"
@@ -274,26 +214,6 @@
           },
           "clientId": {
             "type": "string"
-          },
-          "metadata": {
-            "description": "Custom metadata attached to the inbox",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
-            }
           },
           "updatedAt": {
             "type": "string",
@@ -333,7 +253,7 @@
     {
       "name": "update_inbox",
       "title": "Update Inbox",
-      "description": "Update an inbox's display name or metadata. Metadata keys are merged; set a key to null to remove it, or set metadata to null to clear all.",
+      "description": "Update an inbox's display name.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -344,36 +264,6 @@
           "displayName": {
             "description": "Display name",
             "type": "string"
-          },
-          "metadata": {
-            "description": "Metadata to merge into existing metadata. Set a key to null to remove it, or the whole field to null to clear all metadata",
-            "anyOf": [
-              {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                },
-                "additionalProperties": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "required": [
@@ -398,26 +288,6 @@
           },
           "clientId": {
             "type": "string"
-          },
-          "metadata": {
-            "description": "Custom metadata attached to the inbox",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
-            }
           },
           "updatedAt": {
             "type": "string",
@@ -3273,65 +3143,9 @@
       "oauthOnly": false
     },
     {
-      "name": "auth_me",
-      "title": "Auth Me",
-      "description": "Get the identity and scope of the authenticated credential, including organization, pod, and inbox IDs.",
-      "inputSchema": {
-        "type": "object",
-        "properties": {},
-        "$schema": "http://json-schema.org/draft-07/schema#"
-      },
-      "outputSchema": {
-        "type": "object",
-        "properties": {
-          "scopeType": {
-            "type": "string",
-            "enum": [
-              "organization",
-              "pod",
-              "inbox"
-            ]
-          },
-          "scopeId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "podId": {
-            "type": "string"
-          },
-          "inboxId": {
-            "type": "string"
-          },
-          "apiKeyId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "scopeType",
-          "scopeId",
-          "organizationId"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": false
-      },
-      "annotations": {
-        "title": "Auth Me",
-        "readOnlyHint": true,
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false
-      },
-      "execution": {
-        "taskSupport": "forbidden"
-      },
-      "oauthOnly": false
-    },
-    {
       "name": "list_organizations",
       "title": "List organizations",
-      "description": "List the organizations you belong to and show which one is currently selected for AgentMail operations. Use `select_organization` to change it. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
+      "description": "List the organizations you belong to and show which one is currently effective for this AgentMail session. Use `select_organization` to change an unpinned session. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
       "inputSchema": {
         "type": "object",
         "properties": {}
@@ -3384,7 +3198,7 @@
     {
       "name": "select_organization",
       "title": "Select organization",
-      "description": "Choose which organization your AgentMail operations target (for users who belong to multiple orgs). Accepts an organization name or ID. The choice persists across sessions until you change it. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
+      "description": "Choose which organization your AgentMail operations target (for users who belong to multiple orgs). Accepts an organization name or ID. The choice persists across unpinned sessions until you change it. A session already pinned by OAuth must be reconnected to change organizations. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,6 +33,7 @@ import { AgentMailClient } from 'agentmail'
 import { AgentMailToolkit } from 'agentmail-toolkit/mcp'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { SignJWT } from 'jose'
 import crypto from 'node:crypto'
 import v8 from 'node:v8'
@@ -45,6 +46,14 @@ import { z } from 'zod'
 const PORT = parseInt(process.env.PORT || '3000', 10)
 const DOCS_URL = 'https://docs.agentmail.to/integrations/mcp'
 const OPENAI_APPS_CHALLENGE_TOKEN = 'x5q5TTetk6mOB_sFlNKxXnvES1T8slSZXyWOL-T2b1s'
+export const GENERIC_TOOL_ERROR_MESSAGE =
+    'AgentMail could not complete the request. Retry, and reconnect your account if the problem continues.'
+export const MULTI_ORG_SELECTION_REQUIRED_MESSAGE =
+    'Multiple AgentMail organizations are available. Call `list_organizations`, then `select_organization` before retrying.'
+export const INVALID_ORG_SELECTION_MESSAGE =
+    'No matching organization was found. Call `list_organizations`, then retry `select_organization` with an organization shown there.'
+export const PINNED_ORG_SELECTION_CONFLICT_MESSAGE =
+    'This OAuth session is pinned to a different organization. Reconnect and choose the intended organization, then retry.'
 
 // Where the AgentMail backend lives. Manufact env var should set this per
 // deployment (staging vs prod). The previous behavior was an unset URL =
@@ -218,8 +227,9 @@ export async function getInternalOrganizationId(
                 status: response.status,
                 body,
             })
-            throw new Error(
-                'Your AgentMail workspace is still provisioning. Retry this tool in a few seconds.'
+            throw new ActionableToolError(
+                'Your AgentMail workspace is still provisioning. Retry this tool in a few seconds.',
+                `AgentMail organization mapping is still unavailable for Clerk organization ${clerkOrgId}: ${response.status} ${body}`
             )
         }
         await wait(retryDelaysMs[attempt]!)
@@ -290,8 +300,8 @@ async function setStoredMcpOrgId(clerkUserId: string, orgId: string): Promise<vo
  *      (stored in Clerk privateMetadata). If set and still a valid membership,
  *      use it.
  *   4. Else: refuse. Silently picking memberships[0] could land destructive ops
- *      (e.g. delete_inbox) in the wrong org. Throw a clear error listing the
- *      orgs and telling the user to call `select_organization` first.
+ *      (e.g. delete_inbox) in the wrong org. Tell the user to list and select
+ *      an organization without copying private organization data into the error.
  *
  * Zero memberships is anomalous because Clerk normally creates a user's first
  * organization during sign-up. The MCP server does not create organizations;
@@ -308,9 +318,10 @@ async function buildClientFromClerkUser(
         userId: clerkUserId,
     })
     if (!memberships.data || memberships.data.length === 0) {
-        throw new Error(
-            'Your account has no AgentMail Organization yet. Sign in once at ' +
-                'https://console.agentmail.to to finish setup, then retry this tool.'
+        throw new ActionableToolError(
+            'Your account has no AgentMail organization yet. Sign in at ' +
+                'https://console.agentmail.to to finish setup, then retry this tool.',
+            `Clerk user ${clerkUserId} has no AgentMail organization memberships`
         )
     }
 
@@ -341,9 +352,9 @@ async function buildClientFromClerkUser(
             const orgList = memberships.data
                 .map((m) => `  - ${m.organization.name} (${m.organization.id})`)
                 .join('\n')
-            throw new Error(
-                `You belong to ${memberships.data.length} organizations and haven't selected one yet. ` +
-                    `Call the \`select_organization\` tool with one of these, then retry:\n${orgList}`
+            throw new ActionableToolError(
+                MULTI_ORG_SELECTION_REQUIRED_MESSAGE,
+                `Clerk user ${clerkUserId} has ${memberships.data.length} organizations but no valid selection:\n${orgList}`
             )
         }
         chosenOrg = matching.organization
@@ -389,6 +400,126 @@ type AuthSource =
     | { kind: 'apiKey'; apiKey: string }
     | { kind: 'none' }
 
+export class ActionableToolError extends Error {
+    readonly diagnosticMessage: string
+
+    constructor(
+        readonly publicMessage: string,
+        diagnosticMessage = publicMessage
+    ) {
+        super(publicMessage)
+        this.name = 'ActionableToolError'
+        this.diagnosticMessage = diagnosticMessage
+    }
+}
+
+export function publicToolFailure(context: string, error: unknown): CallToolResult {
+    console.error(`[mcp] ${context} failed:`, error)
+    const message =
+        error instanceof ActionableToolError ? error.publicMessage : GENERIC_TOOL_ERROR_MESSAGE
+    return {
+        content: [{ type: 'text', text: message }],
+        isError: true,
+    }
+}
+
+const INBOX_OUTPUT_TOOL_NAMES = new Set([
+    'list_inboxes',
+    'get_inbox',
+    'create_inbox',
+    'update_inbox',
+])
+
+function omitMetadata<T extends object>(shape: T): Omit<T, 'metadata'> {
+    const { metadata: _metadata, ...withoutMetadata } = shape as T & { metadata?: unknown }
+    return withoutMetadata as Omit<T, 'metadata'>
+}
+
+type ZodObjectLike = {
+    shape: object
+    omit: (mask: { metadata: true }) => unknown
+}
+
+function isZodObjectLike(schema: object): schema is object & ZodObjectLike {
+    const candidate = schema as Partial<ZodObjectLike>
+    return Boolean(candidate.shape) && typeof candidate.omit === 'function'
+}
+
+export function omitHostedInboxMetadataInput<T extends object>(inputSchema: T): T {
+    if (isZodObjectLike(inputSchema)) {
+        return inputSchema.omit({ metadata: true }) as T
+    }
+    return omitMetadata(inputSchema) as T
+}
+
+export function resolveEffectiveSelectedOrganizationId(
+    clerkOrgId: string | undefined,
+    membershipOrgIds: readonly string[],
+    storedOrgId: string | undefined
+): string | undefined {
+    if (clerkOrgId) return clerkOrgId
+    if (membershipOrgIds.length === 1) return membershipOrgIds[0]
+    return storedOrgId
+}
+
+export function conflictsWithPinnedOrganization(
+    clerkOrgId: string | undefined,
+    selectedOrgId: string
+): boolean {
+    return Boolean(clerkOrgId && clerkOrgId !== selectedOrgId)
+}
+
+function stripInboxMetadata(value: unknown): unknown {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+    const { metadata: _metadata, ...withoutMetadata } = value as Record<string, unknown>
+    return withoutMetadata
+}
+
+function sanitizeInboxStructuredContent(
+    toolName: string,
+    structuredContent: Record<string, unknown>
+): Record<string, unknown> {
+    if (toolName === 'list_inboxes') {
+        const inboxes = structuredContent.inboxes
+        return {
+            ...structuredContent,
+            ...(Array.isArray(inboxes)
+                ? { inboxes: inboxes.map((inbox) => stripInboxMetadata(inbox)) }
+                : {}),
+        }
+    }
+    return stripInboxMetadata(structuredContent) as Record<string, unknown>
+}
+
+export function sanitizeHostedToolResult(
+    toolName: string,
+    result: CallToolResult
+): CallToolResult {
+    if (result.isError || !INBOX_OUTPUT_TOOL_NAMES.has(toolName)) {
+        return result
+    }
+    if (!result.structuredContent) {
+        return publicToolFailure(
+            `tool ${toolName}`,
+            new Error('Successful inbox result did not include structuredContent')
+        )
+    }
+
+    const structuredContent = sanitizeInboxStructuredContent(
+        toolName,
+        result.structuredContent
+    )
+    return {
+        ...result,
+        structuredContent,
+        content: result.content.map((item) =>
+            item.type === 'text'
+                ? { ...item, text: JSON.stringify(structuredContent) }
+                : item
+        ),
+    }
+}
+
 // Tool definitions are static metadata (name/description/schemas) — identical
 // for every request — so enumerate them once at module load. Previously each
 // incoming request built its own placeholder AgentMailClient + AgentMailToolkit
@@ -397,7 +528,45 @@ type AuthSource =
 // heap exhaustion. The real, per-auth client is still built inside the tool
 // callback at invocation time.
 const staticToolkit = new AgentMailToolkit(new AgentMailClient({ apiKey: 'placeholder' }))
-const STATIC_TOOLS = staticToolkit.getTools()
+const toolkitTools = staticToolkit.getTools()
+const inboxOutputShape = toolkitTools.find((tool) => tool.name === 'get_inbox')?.outputSchema
+if (!inboxOutputShape) throw new Error('agentmail-toolkit is missing get_inbox output schema')
+const hostedInboxSchema = z.object(omitMetadata(inboxOutputShape))
+
+const STATIC_TOOLS = toolkitTools
+    .filter((tool) => tool.name !== 'auth_me')
+    .map((tool) => {
+        if (tool.name === 'create_inbox') {
+            return {
+                ...tool,
+                description:
+                    'Create a new email inbox. Optionally specify username, domain, and display name.',
+                inputSchema: omitHostedInboxMetadataInput(tool.inputSchema),
+                outputSchema: omitMetadata(tool.outputSchema),
+            }
+        }
+        if (tool.name === 'update_inbox') {
+            return {
+                ...tool,
+                description: "Update an inbox's display name.",
+                inputSchema: omitHostedInboxMetadataInput(tool.inputSchema),
+                outputSchema: omitMetadata(tool.outputSchema),
+            }
+        }
+        if (tool.name === 'get_inbox') {
+            return { ...tool, outputSchema: omitMetadata(tool.outputSchema) }
+        }
+        if (tool.name === 'list_inboxes') {
+            return {
+                ...tool,
+                outputSchema: {
+                    ...tool.outputSchema,
+                    inboxes: z.array(hostedInboxSchema),
+                },
+            }
+        }
+        return tool
+    })
 
 export function createMcpServer(auth: AuthSource): McpServer {
     const server = new McpServer({ name: 'AgentMail', version: '1.0.0' })
@@ -412,6 +581,7 @@ export function createMcpServer(auth: AuthSource): McpServer {
                     'Get an API key at https://console.agentmail.to.',
             },
         ],
+        isError: true,
     }
 
     for (const tool of STATIC_TOOLS) {
@@ -433,19 +603,16 @@ export function createMcpServer(auth: AuthSource): McpServer {
                 const realToolkit = new AgentMailToolkit(client)
                 const realTool = realToolkit.getTools().find((t) => t.name === tool.name)
                 if (!realTool) {
-                    return {
-                        content: [{ type: 'text' as const, text: `Tool ${tool.name} not found in toolkit` }],
-                        isError: true,
-                    }
+                    return publicToolFailure(
+                        `tool ${tool.name}`,
+                        new Error(`Tool ${tool.name} not found in toolkit`)
+                    )
                 }
-                return realTool.callback(args, extra)
+                const result = await realTool.callback(args, extra)
+                if (result.isError) return publicToolFailure(`tool ${tool.name}`, result)
+                return sanitizeHostedToolResult(tool.name, result)
             } catch (error) {
-                const message = error instanceof Error ? error.message : String(error)
-                console.error(`[mcp] tool ${tool.name} failed:`, error)
-                return {
-                    content: [{ type: 'text' as const, text: `Error: ${message}` }],
-                    isError: true,
-                }
+                return publicToolFailure(`tool ${tool.name}`, error)
             }
         })
     }
@@ -466,7 +633,8 @@ export function createMcpServer(auth: AuthSource): McpServer {
                 title: 'List organizations',
                 description:
                     'List the organizations you belong to and show which one is currently ' +
-                    'selected for AgentMail operations. Use `select_organization` to change it. ' +
+                    'effective for this AgentMail session. Use `select_organization` to change ' +
+                    'an unpinned session. ' +
                     'OAuth sessions only -- API-key requests return an error explaining that ' +
                     'organization selection does not apply to API-key authentication.',
                 outputSchema: {
@@ -496,8 +664,17 @@ export function createMcpServer(auth: AuthSource): McpServer {
                     const memberships = await clerkClient.users.getOrganizationMembershipList({
                         userId: auth.clerkUserId,
                     })
-                    const selected = await getStoredMcpOrgId(auth.clerkUserId)
-                    const organizations = (memberships.data ?? []).map((m) => ({
+                    const membershipData = memberships.data ?? []
+                    const stored =
+                        auth.clerkOrgId || membershipData.length === 1
+                            ? undefined
+                            : await getStoredMcpOrgId(auth.clerkUserId)
+                    const selected = resolveEffectiveSelectedOrganizationId(
+                        auth.clerkOrgId,
+                        membershipData.map((m) => m.organization.id),
+                        stored
+                    )
+                    const organizations = membershipData.map((m) => ({
                         id: m.organization.id,
                         name: m.organization.name,
                         selected: m.organization.id === selected,
@@ -508,9 +685,7 @@ export function createMcpServer(auth: AuthSource): McpServer {
                         structuredContent,
                     }
                 } catch (error) {
-                    const message = error instanceof Error ? error.message : String(error)
-                    console.error('[mcp] tool list_organizations failed:', error)
-                    return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+                    return publicToolFailure('tool list_organizations', error)
                 }
             }
         )
@@ -522,9 +697,10 @@ export function createMcpServer(auth: AuthSource): McpServer {
                 description:
                     'Choose which organization your AgentMail operations target (for users who ' +
                     'belong to multiple orgs). Accepts an organization name or ID. The choice ' +
-                    'persists across sessions until you change it. OAuth sessions only -- API-key ' +
-                    'requests return an error explaining that organization selection does not ' +
-                    'apply to API-key authentication.',
+                    'persists across unpinned sessions until you change it. A session already ' +
+                    'pinned by OAuth must be reconnected to change organizations. OAuth sessions ' +
+                    'only -- API-key requests return an error explaining that organization ' +
+                    'selection does not apply to API-key authentication.',
                 inputSchema: {
                     organization: z
                         .string()
@@ -562,17 +738,31 @@ export function createMcpServer(auth: AuthSource): McpServer {
                         const orgList = (memberships.data ?? [])
                             .map((m) => `  - ${m.organization.name} (${m.organization.id})`)
                             .join('\n')
-                        return {
-                            content: [
-                                {
-                                    type: 'text' as const,
-                                    text: `No organization matching "${organization}". You belong to:\n${orgList}`,
-                                },
-                            ],
-                            isError: true,
-                        }
+                        return publicToolFailure(
+                            'tool select_organization',
+                            new ActionableToolError(
+                                INVALID_ORG_SELECTION_MESSAGE,
+                                `No organization matching "${organization}". Available organizations:\n${orgList}`
+                            )
+                        )
                     }
-                    await setStoredMcpOrgId(auth.clerkUserId, match.organization.id)
+                    if (
+                        conflictsWithPinnedOrganization(
+                            auth.clerkOrgId,
+                            match.organization.id
+                        )
+                    ) {
+                        return publicToolFailure(
+                            'tool select_organization',
+                            new ActionableToolError(
+                                PINNED_ORG_SELECTION_CONFLICT_MESSAGE,
+                                `Clerk user ${auth.clerkUserId} requested "${organization}" (${match.organization.id}) while the OAuth session is pinned to ${auth.clerkOrgId}`
+                            )
+                        )
+                    }
+                    if (!auth.clerkOrgId) {
+                        await setStoredMcpOrgId(auth.clerkUserId, match.organization.id)
+                    }
                     const structuredContent = {
                         organizationId: match.organization.id,
                         organizationName: match.organization.name,
@@ -582,9 +772,7 @@ export function createMcpServer(auth: AuthSource): McpServer {
                         structuredContent,
                     }
                 } catch (error) {
-                    const message = error instanceof Error ? error.message : String(error)
-                    console.error('[mcp] tool select_organization failed:', error)
-                    return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+                    return publicToolFailure('tool select_organization', error)
                 }
             }
         )

--- a/tests/server-auth.test.mjs
+++ b/tests/server-auth.test.mjs
@@ -70,3 +70,20 @@ test('am_ API keys sent as Bearer tokens still route to the API-key path', async
   })
   assert.equal(res.status, 200)
 })
+
+test('OpenAI ownership challenge is served verbatim from the exact well-known route', async (t) => {
+  const server = app.listen(0)
+  t.after(() => server.close())
+  await new Promise((resolve) => server.once('listening', resolve))
+  const { port } = server.address()
+
+  const response = await fetch(
+    `http://127.0.0.1:${port}/.well-known/openai-apps-challenge`,
+  )
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get('content-type'), 'text/plain; charset=utf-8')
+  assert.equal(
+    await response.text(),
+    'x5q5TTetk6mOB_sFlNKxXnvES1T8slSZXyWOL-T2b1s',
+  )
+})

--- a/tests/server-contract.test.mjs
+++ b/tests/server-contract.test.mjs
@@ -30,12 +30,12 @@ const coreTools = [
   'update_draft',
   'send_draft',
   'delete_draft',
-  'auth_me',
 ]
 const oauthTools = ['list_organizations', 'select_organization']
 
 test('runtime manifest has the canonical tool contract exactly once', () => {
   const names = manifest.tools.map(({ name }) => name)
+  assert.equal(names.length, 25)
   assert.equal(new Set(names).size, names.length)
   assert.deepEqual(
     names.filter((name) => !oauthTools.includes(name)).sort(),

--- a/tests/server-hosted-hardening.test.mjs
+++ b/tests/server-hosted-hardening.test.mjs
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+
+const requireFromServer = createRequire(
+  new URL('../packages/server/package.json', import.meta.url),
+)
+const { z } = requireFromServer('zod')
+const toolkitPackage = JSON.parse(
+  await readFile(
+    new URL(
+      '../packages/server/node_modules/agentmail-toolkit/package.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+)
+
+process.env.AGENTMAIL_MCP_NO_LISTEN = '1'
+process.env.CLERK_PUBLISHABLE_KEY = 'pk_test_hosted_contract'
+process.env.CLERK_SECRET_KEY = 'sk_test_hosted_contract'
+
+const {
+  ActionableToolError,
+  GENERIC_TOOL_ERROR_MESSAGE,
+  INVALID_ORG_SELECTION_MESSAGE,
+  MULTI_ORG_SELECTION_REQUIRED_MESSAGE,
+  PINNED_ORG_SELECTION_CONFLICT_MESSAGE,
+  conflictsWithPinnedOrganization,
+  createMcpServer,
+  omitHostedInboxMetadataInput,
+  publicToolFailure,
+  resolveEffectiveSelectedOrganizationId,
+  sanitizeHostedToolResult,
+} = await import('../packages/server/build/index.js')
+
+async function listHostedTools() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const server = createMcpServer({ kind: 'apiKey', apiKey: 'contract-only' })
+  const client = new Client({ name: 'hosted-contract-test', version: '1.0.0' })
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  try {
+    return (await client.listTools()).tools
+  } finally {
+    await client.close()
+    await server.close()
+  }
+}
+
+test('hosted catalog exposes exactly 25 tools without auth_me', async () => {
+  const tools = await listHostedTools()
+  const names = tools.map(({ name }) => name)
+
+  assert.equal(names.length, 25)
+  assert.equal(new Set(names).size, 25)
+  assert.ok(names.includes('list_organizations'))
+  assert.ok(names.includes('select_organization'))
+  assert.ok(!names.includes('auth_me'))
+})
+
+test('hosted inbox schemas omit metadata from mutations and all inbox outputs', async () => {
+  const tools = new Map((await listHostedTools()).map((tool) => [tool.name, tool]))
+
+  for (const name of ['create_inbox', 'update_inbox']) {
+    assert.ok(!('metadata' in tools.get(name).inputSchema.properties), `${name} input`)
+    assert.doesNotMatch(tools.get(name).description, /metadata/i)
+  }
+
+  for (const name of ['get_inbox', 'create_inbox', 'update_inbox']) {
+    assert.ok(!('metadata' in tools.get(name).outputSchema.properties), `${name} output`)
+  }
+
+  const inboxItemSchema = tools.get('list_inboxes').outputSchema.properties.inboxes.items
+  assert.ok(!('metadata' in inboxItemSchema.properties), 'list_inboxes item output')
+  assert.equal(inboxItemSchema.additionalProperties, false)
+})
+
+test('metadata omission preserves a full Zod object root policy', () => {
+  const strictInput = z.strictObject({
+    displayName: z.string().optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  })
+  const adapted = omitHostedInboxMetadataInput(strictInput)
+
+  assert.notEqual(adapted, strictInput)
+  assert.ok(!('metadata' in adapted.shape))
+  assert.equal(adapted.safeParse({ displayName: 'Support' }).success, true)
+  assert.equal(
+    adapted.safeParse({ displayName: 'Support', unexpected: true }).success,
+    false,
+    'strict root behavior must survive ZodObject.omit',
+  )
+  assert.equal(
+    adapted.safeParse({ displayName: 'Support', metadata: { private: 'value' } })
+      .success,
+    false,
+    'omitted metadata must be rejected by a strict root',
+  )
+
+  const rawShape = {
+    displayName: z.string().optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+  }
+  const adaptedRawShape = omitHostedInboxMetadataInput(rawShape)
+  assert.ok(!('metadata' in adaptedRawShape))
+  assert.equal(adaptedRawShape.displayName, rawShape.displayName)
+})
+
+test('effective organization selection follows request routing precedence', () => {
+  assert.equal(
+    resolveEffectiveSelectedOrganizationId(
+      'org_oauth',
+      ['org_oauth', 'org_stored'],
+      'org_stored',
+    ),
+    'org_oauth',
+  )
+  assert.equal(
+    resolveEffectiveSelectedOrganizationId(undefined, ['org_only'], 'org_stale'),
+    'org_only',
+  )
+  assert.equal(
+    resolveEffectiveSelectedOrganizationId(
+      undefined,
+      ['org_first', 'org_stored'],
+      'org_stored',
+    ),
+    'org_stored',
+  )
+  assert.equal(
+    resolveEffectiveSelectedOrganizationId(
+      undefined,
+      ['org_first', 'org_second'],
+      undefined,
+    ),
+    undefined,
+  )
+})
+
+test('pinned organization selection only permits a truthful no-op', () => {
+  assert.equal(
+    conflictsWithPinnedOrganization('org_oauth', 'org_oauth'),
+    false,
+  )
+  assert.equal(
+    conflictsWithPinnedOrganization('org_oauth', 'org_different'),
+    true,
+  )
+  assert.equal(
+    conflictsWithPinnedOrganization(undefined, 'org_different'),
+    false,
+  )
+  assert.doesNotMatch(
+    PINNED_ORG_SELECTION_CONFLICT_MESSAGE,
+    /org_oauth|org_different|Secret Org|requested/i,
+  )
+  assert.match(PINNED_ORG_SELECTION_CONFLICT_MESSAGE, /Reconnect/)
+})
+
+test('hosted inbox results strip metadata from structured content and text', () => {
+  const inbox = {
+    podId: 'pod_1',
+    inboxId: 'inbox_1',
+    email: 'test@example.com',
+    metadata: { private: 'never expose' },
+    updatedAt: '2026-07-24T00:00:00Z',
+    createdAt: '2026-07-24T00:00:00Z',
+  }
+
+  for (const name of ['get_inbox', 'create_inbox', 'update_inbox']) {
+    const result = sanitizeHostedToolResult(name, {
+      structuredContent: inbox,
+      content: [{ type: 'text', text: JSON.stringify(inbox) }],
+      isError: false,
+    })
+    assert.ok(!('metadata' in result.structuredContent), `${name} structured content`)
+    assert.ok(!('metadata' in JSON.parse(result.content[0].text)), `${name} text content`)
+  }
+
+  const listResult = sanitizeHostedToolResult('list_inboxes', {
+    structuredContent: { count: 1, inboxes: [inbox] },
+    content: [{ type: 'text', text: JSON.stringify({ count: 1, inboxes: [inbox] }) }],
+    isError: false,
+  })
+  assert.ok(!('metadata' in listResult.structuredContent.inboxes[0]))
+  assert.ok(!('metadata' in JSON.parse(listResult.content[0].text).inboxes[0]))
+})
+
+test('public failures are stable and actionable while logs retain diagnostics', () => {
+  const logged = []
+  const originalConsoleError = console.error
+  console.error = (...args) => logged.push(args)
+  try {
+    const unexpected = new Error(
+      'Clerk failed for user_123 in org_private named Highly Confidential',
+    )
+    const unexpectedResult = publicToolFailure('tool list_inboxes', unexpected)
+    assert.equal(unexpectedResult.content[0].text, GENERIC_TOOL_ERROR_MESSAGE)
+    assert.equal(unexpectedResult.isError, true)
+    assert.equal(logged[0][1], unexpected)
+
+    const actionable = new ActionableToolError(
+      MULTI_ORG_SELECTION_REQUIRED_MESSAGE,
+      'user_123 belongs to Secret Org (org_private)',
+    )
+    const actionableResult = publicToolFailure('tool list_inboxes', actionable)
+    assert.equal(
+      actionableResult.content[0].text,
+      MULTI_ORG_SELECTION_REQUIRED_MESSAGE,
+    )
+    assert.equal(logged[1][1], actionable)
+    assert.equal(
+      actionable.diagnosticMessage,
+      'user_123 belongs to Secret Org (org_private)',
+    )
+  } finally {
+    console.error = originalConsoleError
+  }
+
+  for (const message of [
+    MULTI_ORG_SELECTION_REQUIRED_MESSAGE,
+    INVALID_ORG_SELECTION_MESSAGE,
+  ]) {
+    assert.doesNotMatch(message, /user_123|org_private|Highly Confidential|Secret Org/)
+    assert.match(message, /list_organizations/)
+    assert.match(message, /select_organization/)
+  }
+})
+
+function propertyPaths(schema, path = []) {
+  if (!schema || typeof schema !== 'object') return []
+  const paths = []
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const [name, child] of Object.entries(schema.properties)) {
+      const childPath = [...path, name]
+      paths.push(childPath, ...propertyPaths(child, childPath))
+    }
+  }
+  if (schema.items) paths.push(...propertyPaths(schema.items, [...path, '[]']))
+  for (const keyword of ['anyOf', 'oneOf', 'allOf']) {
+    if (!Array.isArray(schema[keyword])) continue
+    for (const variant of schema[keyword]) {
+      paths.push(...propertyPaths(variant, path))
+    }
+  }
+  return paths
+}
+
+function unionNodes(schema, path = []) {
+  if (!schema || typeof schema !== 'object') return []
+  const nodes = []
+  for (const keyword of ['anyOf', 'oneOf']) {
+    if (Array.isArray(schema[keyword])) {
+      nodes.push({ path, variants: schema[keyword] })
+    }
+  }
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const [name, child] of Object.entries(schema.properties)) {
+      nodes.push(...unionNodes(child, [...path, name]))
+    }
+  }
+  if (schema.items) nodes.push(...unionNodes(schema.items, [...path, '[]']))
+  for (const keyword of ['anyOf', 'oneOf', 'allOf']) {
+    if (!Array.isArray(schema[keyword])) continue
+    for (const variant of schema[keyword]) {
+      nodes.push(...unionNodes(variant, path))
+    }
+  }
+  return nodes
+}
+
+function structurallyExcludes(schema, property) {
+  if (
+    schema.additionalProperties === false &&
+    !(property in (schema.properties ?? {}))
+  ) {
+    return true
+  }
+  return Boolean(schema.not?.required?.includes(property))
+}
+
+function toolkitSupportsPost052Contract(version) {
+  const [major = 0, minor = 0, patch = 0] = version
+    .split(/[.-]/, 3)
+    .map((part) => Number.parseInt(part, 10))
+  return major > 0 || minor > 5 || (minor === 5 && patch >= 2)
+}
+
+test(
+  'agentmail-toolkit >=0.5.2 satisfies hosted approval schema invariants',
+  {
+    skip: toolkitSupportsPost052Contract(toolkitPackage.version)
+      ? false
+      : `requires agentmail-toolkit >=0.5.2; installed ${toolkitPackage.version}`,
+  },
+  async () => {
+    const tools = new Map((await listHostedTools()).map((tool) => [tool.name, tool]))
+    const forbiddenOutputProperties = new Set([
+      'podId',
+      'clientId',
+      'headers',
+      'extractionError',
+    ])
+    const violations = []
+    for (const tool of tools.values()) {
+      for (const path of propertyPaths(tool.outputSchema)) {
+        if (forbiddenOutputProperties.has(path.at(-1))) {
+          violations.push(`${tool.name}.${path.join('.')}`)
+        }
+      }
+    }
+    assert.deepEqual(violations, [])
+
+    for (const name of [
+      'send_message',
+      'reply_to_message',
+      'forward_message',
+      'create_draft',
+    ]) {
+      const itemSchema = tools.get(name).inputSchema.properties.attachments.items
+      const variants = itemSchema.anyOf ?? itemSchema.oneOf
+      assert.ok(Array.isArray(variants), `${name} attachment union`)
+      const contentBranch = variants.find((variant) =>
+        variant.required?.includes('content'),
+      )
+      const urlBranch = variants.find((variant) =>
+        variant.required?.includes('url'),
+      )
+      assert.ok(contentBranch, `${name} content attachment branch`)
+      assert.ok(urlBranch, `${name} URL attachment branch`)
+      assert.ok(
+        structurallyExcludes(contentBranch, 'url'),
+        `${name} content branch must exclude URL`,
+      )
+      assert.ok(
+        structurallyExcludes(urlBranch, 'content'),
+        `${name} URL branch must exclude content`,
+      )
+    }
+
+    const replyModeUnion = unionNodes(
+      tools.get('reply_to_message').inputSchema,
+    ).find(({ path, variants }) => {
+      if (path.includes('attachments') || path.length === 0) return false
+      const serialized = JSON.stringify(variants)
+      return /replyAll|recipient|sender/i.test(serialized)
+    })
+    assert.ok(replyModeUnion, 'reply recipient modes must be a nested union')
+    assert.ok(replyModeUnion.variants.length >= 2)
+  },
+)


### PR DESCRIPTION
## Summary

- Remove auth_me from the hosted catalog while retaining explicit organization-selection tools.
- Remove inbox metadata from hosted create/update inputs and inbox outputs.
- Sanitize structured and text results plus unexpected authentication, Clerk, organization, and upstream errors.
- Correct effective organization-selection reporting and OAuth-pinned selection behavior.
- Regenerate the hosted manifest at exactly 25 tools.
- Add exact OpenAI ownership-challenge, schema, output, error, and organization-routing tests.

## Verification

- Frozen install, monorepo build, manifest generation, and contract check passed.
- Current suite passed: 4 bridge tests, 18 server tests, and 4 Python tests; the registry-dependent 0.5.2 acceptance test is correctly skipped.
- A temporary end-to-end install of the local agentmail-toolkit 0.5.2 tarball passed build, contract checks, and all 8 approval invariants with no skips.
- git diff check passed.

## Merge blockers

- agentmail-toolkit 0.5.2 is not published. This draft intentionally remains pinned to 0.5.1. Publish 0.5.2, update package.json and pnpm-lock.yaml, regenerate the manifest, and rerun the full suite before merge.
- The production exact ownership-challenge URL currently returns a Cloudflare 404 even though the source route passes locally. Fix the edge route/cache before resubmission.
- Do not deploy or resubmit the OpenAI plugin from the current draft manifest.