### PR TITLE
fix(server): consensus hosted-surface trim (replaces #32)

### DIFF
--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "server": "to.agentmail/agentmail",
   "endpoint": "https://mcp.agentmail.to/mcp",
-  "digest": "sha256:25908bd6aeeb5567547e34b0b336b41cff8eb68e67466e7082fedfe0d9d0cfa0",
+  "digest": "sha256:61c307d233cfad695f17682c4d813f22ec2b7f419b594163e6b953cabd7e2ce4",
   "tools": [
     {
       "name": "list_inboxes",
@@ -3273,62 +3273,6 @@
       "oauthOnly": false
     },
     {
-      "name": "auth_me",
-      "title": "Auth Me",
-      "description": "Get the identity and scope of the authenticated credential, including organization, pod, and inbox IDs.",
-      "inputSchema": {
-        "type": "object",
-        "properties": {},
-        "$schema": "http://json-schema.org/draft-07/schema#"
-      },
-      "outputSchema": {
-        "type": "object",
-        "properties": {
-          "scopeType": {
-            "type": "string",
-            "enum": [
-              "organization",
-              "pod",
-              "inbox"
-            ]
-          },
-          "scopeId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "podId": {
-            "type": "string"
-          },
-          "inboxId": {
-            "type": "string"
-          },
-          "apiKeyId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "scopeType",
-          "scopeId",
-          "organizationId"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "additionalProperties": false
-      },
-      "annotations": {
-        "title": "Auth Me",
-        "readOnlyHint": true,
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false
-      },
-      "execution": {
-        "taskSupport": "forbidden"
-      },
-      "oauthOnly": false
-    },
-    {
       "name": "list_organizations",
       "title": "List organizations",
       "description": "List the organizations you belong to and show which one is currently selected for AgentMail operations. Use `select_organization` to change it. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
@@ -3384,7 +3328,7 @@
     {
       "name": "select_organization",
       "title": "Select organization",
-      "description": "Choose which organization your AgentMail operations target (for users who belong to multiple orgs). Accepts an organization name or ID. The choice persists across sessions until you change it. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
+      "description": "Choose which organization your AgentMail operations target (for users who belong to multiple orgs). Accepts an organization name or ID. The choice persists across unpinned sessions until you change it; a session already pinned to an organization by OAuth must be reconnected to change it. OAuth sessions only -- API-key requests return an error explaining that organization selection does not apply to API-key authentication.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "server": "to.agentmail/agentmail",
   "endpoint": "https://mcp.agentmail.to/mcp",
-  "digest": "sha256:61c307d233cfad695f17682c4d813f22ec2b7f419b594163e6b953cabd7e2ce4",
+  "digest": "sha256:b4ddde565ed29ab7389e3024cc5df1f2347408eb5c8dff3b9459de9131056f45",
   "tools": [
     {
       "name": "list_inboxes",
@@ -43,9 +43,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "podId": {
-                  "type": "string"
-                },
                 "inboxId": {
                   "type": "string"
                 },
@@ -53,9 +50,6 @@
                   "type": "string"
                 },
                 "displayName": {
-                  "type": "string"
-                },
-                "clientId": {
                   "type": "string"
                 },
                 "metadata": {
@@ -92,13 +86,12 @@
                 }
               },
               "required": [
-                "podId",
                 "inboxId",
                 "email",
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -141,9 +134,6 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "podId": {
-            "type": "string"
-          },
           "inboxId": {
             "type": "string"
           },
@@ -151,9 +141,6 @@
             "type": "string"
           },
           "displayName": {
-            "type": "string"
-          },
-          "clientId": {
             "type": "string"
           },
           "metadata": {
@@ -190,7 +177,6 @@
           }
         },
         "required": [
-          "podId",
           "inboxId",
           "email",
           "updatedAt",
@@ -260,9 +246,6 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "podId": {
-            "type": "string"
-          },
           "inboxId": {
             "type": "string"
           },
@@ -270,9 +253,6 @@
             "type": "string"
           },
           "displayName": {
-            "type": "string"
-          },
-          "clientId": {
             "type": "string"
           },
           "metadata": {
@@ -309,7 +289,6 @@
           }
         },
         "required": [
-          "podId",
           "inboxId",
           "email",
           "updatedAt",
@@ -384,9 +363,6 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "podId": {
-            "type": "string"
-          },
           "inboxId": {
             "type": "string"
           },
@@ -394,9 +370,6 @@
             "type": "string"
           },
           "displayName": {
-            "type": "string"
-          },
-          "clientId": {
             "type": "string"
           },
           "metadata": {
@@ -433,7 +406,6 @@
           }
         },
         "required": [
-          "podId",
           "inboxId",
           "email",
           "updatedAt",
@@ -667,7 +639,7 @@
                       "attachmentId",
                       "size"
                     ],
-                    "additionalProperties": {}
+                    "additionalProperties": false
                   }
                 },
                 "lastMessageId": {
@@ -705,7 +677,7 @@
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -863,7 +835,7 @@
                       "attachmentId",
                       "size"
                     ],
-                    "additionalProperties": {}
+                    "additionalProperties": false
                   }
                 },
                 "lastMessageId": {
@@ -886,6 +858,41 @@
                   "format": "date-time",
                   "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
                   "description": "ISO 8601 datetime"
+                },
+                "highlights": {
+                  "description": "Matched fragments per field, present when the query matched an indexed field",
+                  "type": "object",
+                  "properties": {
+                    "from": {
+                      "description": "Matched fragments from the sender address",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "recipients": {
+                      "description": "Matched fragments from recipient addresses",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "subject": {
+                      "description": "Matched fragments from the subject",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "text": {
+                      "description": "Matched fragments from the body",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [
@@ -901,7 +908,7 @@
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -1025,7 +1032,7 @@
                 "attachmentId",
                 "size"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           },
           "lastMessageId": {
@@ -1130,7 +1137,7 @@
                       "attachmentId",
                       "size"
                     ],
-                    "additionalProperties": {}
+                    "additionalProperties": false
                   }
                 },
                 "inReplyTo": {
@@ -1139,15 +1146,6 @@
                 "references": {
                   "type": "array",
                   "items": {
-                    "type": "string"
-                  }
-                },
-                "headers": {
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {
                     "type": "string"
                   }
                 },
@@ -1197,7 +1195,7 @@
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             },
             "description": "Messages in thread, ordered by timestamp ascending"
           }
@@ -1290,11 +1288,7 @@
             "description": "Time at which the download URL expires"
           },
           "text": {
-            "description": "Extracted text (PDF/DOCX only, toolkit-added)",
-            "type": "string"
-          },
-          "extractionError": {
-            "description": "Set when PDF/DOCX text extraction failed or was skipped (toolkit-added)",
+            "description": "Extracted text (PDF/DOCX only, toolkit-added; absent when extraction was skipped or failed - see download URL)",
             "type": "string"
           }
         },
@@ -1605,7 +1599,7 @@
                       "attachmentId",
                       "size"
                     ],
-                    "additionalProperties": {}
+                    "additionalProperties": false
                   }
                 },
                 "inReplyTo": {
@@ -1614,15 +1608,6 @@
                 "references": {
                   "type": "array",
                   "items": {
-                    "type": "string"
-                  }
-                },
-                "headers": {
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {
                     "type": "string"
                   }
                 },
@@ -1654,7 +1639,7 @@
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -1812,7 +1797,7 @@
                       "attachmentId",
                       "size"
                     ],
-                    "additionalProperties": {}
+                    "additionalProperties": false
                   }
                 },
                 "inReplyTo": {
@@ -1821,15 +1806,6 @@
                 "references": {
                   "type": "array",
                   "items": {
-                    "type": "string"
-                  }
-                },
-                "headers": {
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {
                     "type": "string"
                   }
                 },
@@ -1847,6 +1823,41 @@
                   "format": "date-time",
                   "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
                   "description": "ISO 8601 datetime"
+                },
+                "highlights": {
+                  "description": "Matched fragments per field, present when the query matched an indexed field",
+                  "type": "object",
+                  "properties": {
+                    "from": {
+                      "description": "Matched fragments from the sender address",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "recipients": {
+                      "description": "Matched fragments from recipient addresses",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "subject": {
+                      "description": "Matched fragments from the subject",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "text": {
+                      "description": "Matched fragments from the body",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [
@@ -1861,7 +1872,7 @@
                 "updatedAt",
                 "createdAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -1914,38 +1925,76 @@
             "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "filename": {
-                  "description": "Filename",
-                  "type": "string"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "Base64 encoded content"
+                    }
+                  },
+                  "required": [
+                    "content"
+                  ],
+                  "additionalProperties": false
                 },
-                "contentType": {
-                  "description": "MIME type of the attachment",
-                  "type": "string"
-                },
-                "contentDisposition": {
-                  "description": "Content disposition",
-                  "type": "string",
-                  "enum": [
-                    "inline",
-                    "attachment"
-                  ]
-                },
-                "contentId": {
-                  "description": "Content ID for inline attachments",
-                  "type": "string"
-                },
-                "content": {
-                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
-                  "type": "string"
-                },
-                "url": {
-                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
-                  "type": "string",
-                  "format": "uri"
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Publicly accessible URL to fetch the attachment from"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "additionalProperties": false
                 }
-              }
+              ],
+              "description": "Attachment: provide exactly one of content (base64) or url"
             }
           },
           "to": {
@@ -2046,38 +2095,76 @@
             "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "filename": {
-                  "description": "Filename",
-                  "type": "string"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "Base64 encoded content"
+                    }
+                  },
+                  "required": [
+                    "content"
+                  ],
+                  "additionalProperties": false
                 },
-                "contentType": {
-                  "description": "MIME type of the attachment",
-                  "type": "string"
-                },
-                "contentDisposition": {
-                  "description": "Content disposition",
-                  "type": "string",
-                  "enum": [
-                    "inline",
-                    "attachment"
-                  ]
-                },
-                "contentId": {
-                  "description": "Content ID for inline attachments",
-                  "type": "string"
-                },
-                "content": {
-                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
-                  "type": "string"
-                },
-                "url": {
-                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
-                  "type": "string",
-                  "format": "uri"
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Publicly accessible URL to fetch the attachment from"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "additionalProperties": false
                 }
-              }
+              ],
+              "description": "Attachment: provide exactly one of content (base64) or url"
             }
           },
           "messageId": {
@@ -2182,38 +2269,76 @@
             "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "filename": {
-                  "description": "Filename",
-                  "type": "string"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "Base64 encoded content"
+                    }
+                  },
+                  "required": [
+                    "content"
+                  ],
+                  "additionalProperties": false
                 },
-                "contentType": {
-                  "description": "MIME type of the attachment",
-                  "type": "string"
-                },
-                "contentDisposition": {
-                  "description": "Content disposition",
-                  "type": "string",
-                  "enum": [
-                    "inline",
-                    "attachment"
-                  ]
-                },
-                "contentId": {
-                  "description": "Content ID for inline attachments",
-                  "type": "string"
-                },
-                "content": {
-                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
-                  "type": "string"
-                },
-                "url": {
-                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
-                  "type": "string",
-                  "format": "uri"
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Publicly accessible URL to fetch the attachment from"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "additionalProperties": false
                 }
-              }
+              ],
+              "description": "Attachment: provide exactly one of content (base64) or url"
             }
           },
           "to": {
@@ -2387,38 +2512,76 @@
             "description": "Attachments. Each item must specify exactly one of content (base64) or url",
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "filename": {
-                  "description": "Filename",
-                  "type": "string"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "Base64 encoded content"
+                    }
+                  },
+                  "required": [
+                    "content"
+                  ],
+                  "additionalProperties": false
                 },
-                "contentType": {
-                  "description": "MIME type of the attachment",
-                  "type": "string"
-                },
-                "contentDisposition": {
-                  "description": "Content disposition",
-                  "type": "string",
-                  "enum": [
-                    "inline",
-                    "attachment"
-                  ]
-                },
-                "contentId": {
-                  "description": "Content ID for inline attachments",
-                  "type": "string"
-                },
-                "content": {
-                  "description": "Base64 encoded content. Exactly one of content or url must be provided",
-                  "type": "string"
-                },
-                "url": {
-                  "description": "Publicly accessible URL to fetch the attachment from. Exactly one of content or url must be provided",
-                  "type": "string",
-                  "format": "uri"
+                {
+                  "type": "object",
+                  "properties": {
+                    "filename": {
+                      "description": "Filename",
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "description": "MIME type of the attachment",
+                      "type": "string"
+                    },
+                    "contentDisposition": {
+                      "description": "Content disposition",
+                      "type": "string",
+                      "enum": [
+                        "inline",
+                        "attachment"
+                      ]
+                    },
+                    "contentId": {
+                      "description": "Content ID for inline attachments",
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Publicly accessible URL to fetch the attachment from"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "additionalProperties": false
                 }
-              }
+              ],
+              "description": "Attachment: provide exactly one of content (base64) or url"
             }
           },
           "to": {
@@ -2538,7 +2701,7 @@
                 "attachmentId",
                 "size"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           },
           "inReplyTo": {
@@ -2563,9 +2726,6 @@
             "format": "date-time",
             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
             "description": "ISO 8601 datetime"
-          },
-          "clientId": {
-            "type": "string"
           },
           "replyTo": {
             "type": "array",
@@ -2743,7 +2903,7 @@
                       "attachmentId",
                       "size"
                     ],
-                    "additionalProperties": {}
+                    "additionalProperties": false
                   }
                 },
                 "inReplyTo": {
@@ -2776,7 +2936,7 @@
                 "labels",
                 "updatedAt"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           }
         },
@@ -2888,7 +3048,7 @@
                 "attachmentId",
                 "size"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           },
           "inReplyTo": {
@@ -2913,9 +3073,6 @@
             "format": "date-time",
             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
             "description": "ISO 8601 datetime"
-          },
-          "clientId": {
-            "type": "string"
           },
           "replyTo": {
             "type": "array",
@@ -3097,7 +3254,7 @@
                 "attachmentId",
                 "size"
               ],
-              "additionalProperties": {}
+              "additionalProperties": false
             }
           },
           "inReplyTo": {
@@ -3122,9 +3279,6 @@
             "format": "date-time",
             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
             "description": "ISO 8601 datetime"
-          },
-          "clientId": {
-            "type": "string"
           },
           "replyTo": {
             "type": "array",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "@clerk/mcp-tools": "0.3.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "agentmail": "0.5.14",
-    "agentmail-toolkit": "0.5.1",
+    "agentmail-toolkit": "0.6.0",
     "cors": "2.8.5",
     "express": "5.2.1",
     "jose": "5.9.6",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -397,7 +397,12 @@ type AuthSource =
 // heap exhaustion. The real, per-auth client is still built inside the tool
 // callback at invocation time.
 const staticToolkit = new AgentMailToolkit(new AgentMailClient({ apiKey: 'placeholder' }))
-const STATIC_TOOLS = staticToolkit.getTools()
+// auth_me is excluded from the HOSTED catalog only (it stays in the toolkit for
+// other integrations): it returns organization/pod/API-key identifiers, which
+// OpenAI app review treats as unnecessary internal identifiers on this surface —
+// disclosure cannot cure "unnecessary". Hosted sessions get org context via
+// list_organizations/select_organization instead.
+const STATIC_TOOLS = staticToolkit.getTools().filter((tool) => tool.name !== 'auth_me')
 
 export function createMcpServer(auth: AuthSource): McpServer {
     const server = new McpServer({ name: 'AgentMail', version: '1.0.0' })
@@ -412,6 +417,9 @@ export function createMcpServer(auth: AuthSource): McpServer {
                     'Get an API key at https://console.agentmail.to.',
             },
         ],
+        // isError so clients surface it as an actionable failure instead of a
+        // success payload that models may misread as tool output.
+        isError: true,
     }
 
     for (const tool of STATIC_TOOLS) {
@@ -496,8 +504,19 @@ export function createMcpServer(auth: AuthSource): McpServer {
                     const memberships = await clerkClient.users.getOrganizationMembershipList({
                         userId: auth.clerkUserId,
                     })
-                    const selected = await getStoredMcpOrgId(auth.clerkUserId)
-                    const organizations = (memberships.data ?? []).map((m) => ({
+                    // Report the EFFECTIVE org, mirroring buildClientFromClerkUser's
+                    // precedence (token-pinned > single-org auto-pick > stored choice) —
+                    // previously only the stored choice was reported, so pinned and
+                    // single-org sessions showed nothing selected.
+                    const membershipData = memberships.data ?? []
+                    const stored =
+                        auth.clerkOrgId || membershipData.length === 1
+                            ? undefined
+                            : await getStoredMcpOrgId(auth.clerkUserId)
+                    const selected =
+                        auth.clerkOrgId ??
+                        (membershipData.length === 1 ? membershipData[0]!.organization.id : stored)
+                    const organizations = membershipData.map((m) => ({
                         id: m.organization.id,
                         name: m.organization.name,
                         selected: m.organization.id === selected,
@@ -522,9 +541,10 @@ export function createMcpServer(auth: AuthSource): McpServer {
                 description:
                     'Choose which organization your AgentMail operations target (for users who ' +
                     'belong to multiple orgs). Accepts an organization name or ID. The choice ' +
-                    'persists across sessions until you change it. OAuth sessions only -- API-key ' +
-                    'requests return an error explaining that organization selection does not ' +
-                    'apply to API-key authentication.',
+                    'persists across unpinned sessions until you change it; a session already ' +
+                    'pinned to an organization by OAuth must be reconnected to change it. OAuth ' +
+                    'sessions only -- API-key requests return an error explaining that ' +
+                    'organization selection does not apply to API-key authentication.',
                 inputSchema: {
                     organization: z
                         .string()
@@ -572,7 +592,26 @@ export function createMcpServer(auth: AuthSource): McpServer {
                             isError: true,
                         }
                     }
-                    await setStoredMcpOrgId(auth.clerkUserId, match.organization.id)
+                    // A token-pinned session routes by its org_id claim regardless of the
+                    // stored choice (buildClientFromClerkUser path 1), so selecting a
+                    // DIFFERENT org would silently not take effect — refuse instead.
+                    // Selecting the already-pinned org is a truthful no-op.
+                    if (auth.clerkOrgId && auth.clerkOrgId !== match.organization.id) {
+                        return {
+                            content: [
+                                {
+                                    type: 'text' as const,
+                                    text:
+                                        'This OAuth session is pinned to a different organization. ' +
+                                        'Reconnect and choose the intended organization, then retry.',
+                                },
+                            ],
+                            isError: true,
+                        }
+                    }
+                    if (!auth.clerkOrgId) {
+                        await setStoredMcpOrgId(auth.clerkUserId, match.organization.id)
+                    }
                     const structuredContent = {
                         organizationId: match.organization.id,
                         organizationName: match.organization.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 0.5.14
         version: 0.5.14
       agentmail-toolkit:
-        specifier: 0.5.1
-        version: 0.5.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+        specifier: 0.6.0
+        version: 0.6.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -174,8 +174,8 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  agentmail-toolkit@0.5.1:
-    resolution: {integrity: sha512-BHyDtgmXI8UnZDPsWICM3/SvBVZ0J+zxWWOTeUT+YP5d0bD98vXy7kaU2960ER11u9TfneqWpdbx88jzbd/M0g==}
+  agentmail-toolkit@0.6.0:
+    resolution: {integrity: sha512-WoRwa2fJhaeDPFWNFc5n79ov6Fn5ogg06EQFd0Xd6yJqSF3u+n2/9WVGhDpmzZEpGTyyYWkVf8PVXtsXcm1YoQ==}
     peerDependencies:
       '@mariozechner/pi-agent-core': ^0.50.1
       '@modelcontextprotocol/sdk': ^1.24.1
@@ -768,7 +768,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agentmail-toolkit@0.5.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)):
+  agentmail-toolkit@0.6.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)):
     dependencies:
       agentmail: 0.5.14
       jszip: 3.10.1

--- a/tests/server-contract.test.mjs
+++ b/tests/server-contract.test.mjs
@@ -30,7 +30,9 @@ const coreTools = [
   'update_draft',
   'send_draft',
   'delete_draft',
-  'auth_me',
+  // auth_me is deliberately absent: excluded from the hosted catalog only
+  // (organization/pod/API-key identifiers are unnecessary on the OpenAI
+  // surface); it remains available in agentmail-toolkit for other consumers.
 ]
 const oauthTools = ['list_organizations', 'select_organization']
 


### PR DESCRIPTION
The Claude/Codex consensus subset of #32, reimplemented minimally on main — see commit message for what's in and what's deliberately out. Supersedes #32.

- Org-selection reporting/pinning corrections + `noAuthMessage isError` + hosted-only `auth_me` exclusion (manifest regenerated, contract check green, all server tests passing).
- Excluded per consensus: generic-error blanket, metadata stripping, parallel schema reconstruction, impossible-scenario guards.
- Note: this repo is NOT the currently-scanned deployment (Manufact is). This PR matters at cutover; the 0.6.0 toolkit bump + another manifest regen land in a follow-up once agentmail-toolkit 0.6.0 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)