### PR TITLE
fix: report npm bridge transport errors

### DIFF
--- a/packages/npm-stdio-bridge/package.json
+++ b/packages/npm-stdio-bridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agentmail-mcp",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "stdio compatibility bridge for the hosted AgentMail MCP server",
     "keywords": [
         "agentmail",

--- a/packages/npm-stdio-bridge/src/index.ts
+++ b/packages/npm-stdio-bridge/src/index.ts
@@ -16,10 +16,10 @@ import {
     type Progress,
 } from '@modelcontextprotocol/sdk/types.js'
 
-const VERSION = '1.0.1'
+const VERSION = '1.0.2'
 const ENDPOINT = new URL('https://mcp.agentmail.to/mcp')
-const BRIDGE_HEADER = 'node/1.0.1'
-const USER_AGENT = 'agentmail-mcp-node/1.0.1'
+const BRIDGE_HEADER = 'node/1.0.2'
+const USER_AGENT = 'agentmail-mcp-node/1.0.2'
 
 export function parseTools(args: string[]) {
     const index = args.indexOf('--tools')
@@ -78,6 +78,8 @@ export async function startBridge(remoteTransport: Transport, localTransport: Tr
         )
     })
 
+    server.onerror = (error) => console.error(`AgentMail MCP: stdio error: ${error.message}`)
+    client.onerror = (error) => console.error(`AgentMail MCP: hosted error: ${error.message}`)
     server.onclose = () => void client.close()
     client.onclose = () => void server.close()
     await client.connect(remoteTransport)

--- a/packages/npm-stdio-bridge/test/artifact.test.mjs
+++ b/packages/npm-stdio-bridge/test/artifact.test.mjs
@@ -8,15 +8,15 @@ import test from 'node:test'
 
 test('published artifact is an executable bridge without AgentMail implementation dependencies', async (t) => {
     const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-    assert.equal(packageJson.version, '1.0.1')
+    assert.equal(packageJson.version, '1.0.2')
     assert.deepEqual(packageJson.dependencies, { '@modelcontextprotocol/sdk': '1.29.0' })
 
     const built = await readFile(new URL('../build/index.js', import.meta.url), 'utf8')
     assert.match(built, /^#!\/usr\/bin\/env node/)
     assert.match(built, /https:\/\/mcp\.agentmail\.to\/mcp/)
     assert.match(built, /X-AgentMail-MCP-Bridge/)
-    assert.match(built, /node\/1\.0\.1/)
-    assert.match(built, /agentmail-mcp-node\/1\.0\.1/)
+    assert.match(built, /node\/1\.0\.2/)
+    assert.match(built, /agentmail-mcp-node\/1\.0\.2/)
     assert.doesNotMatch(built, /agentmail-toolkit|from ['"]agentmail['"]|list_inboxes|send_message/)
     assert.ok((await stat(new URL('../build/index.js', import.meta.url))).mode & 0o111)
 

--- a/packages/npm-stdio-bridge/test/bridge.test.mjs
+++ b/packages/npm-stdio-bridge/test/bridge.test.mjs
@@ -41,6 +41,30 @@ test('does not open stdio when the hosted connection fails', async () => {
     assert.equal(localStarted, false)
 })
 
+test('reports hosted and stdio transport errors to stderr', async (t) => {
+    const [remoteServerTransport, bridgeRemoteTransport] = InMemoryTransport.createLinkedPair()
+    const [bridgeLocalTransport] = InMemoryTransport.createLinkedPair()
+    const remote = new Server({ name: 'remote', version: '1.0.0' }, { capabilities: { tools: {} } })
+    await remote.connect(remoteServerTransport)
+    await startBridge(bridgeRemoteTransport, bridgeLocalTransport)
+    t.after(() => remote.close())
+
+    const messages = []
+    const original = console.error
+    console.error = (message) => messages.push(message)
+    try {
+        bridgeRemoteTransport.onerror(new Error('hosted boom'))
+        bridgeLocalTransport.onerror(new Error('stdio boom'))
+    } finally {
+        console.error = original
+    }
+
+    assert.deepEqual(messages, [
+        'AgentMail MCP: hosted error: hosted boom',
+        'AgentMail MCP: stdio error: stdio boom',
+    ])
+})
+
 test('forwards the remote tool contract, calls, errors, progress, cancellation, and changes', async (t) => {
     const [remoteServerTransport, bridgeRemoteTransport] = InMemoryTransport.createLinkedPair()
     const [bridgeLocalTransport, localClientTransport] = InMemoryTransport.createLinkedPair()


### PR DESCRIPTION
## Summary

- report hosted and stdio transport/protocol errors to stderr instead of dropping them
- preserve stdout for JSON-RPC and leave shutdown, exit-code, timeout, and SDK retry behavior unchanged
- bump the npm bridge to 1.0.2 so the merged fix is published by the release workflow

## Why

The bridge did not install client.onerror or server.onerror handlers. Errors delivered through those SDK callbacks therefore had no diagnostic output, leaving operators without the underlying hosted or stdio failure.

This PR deliberately does not claim to fix silent process exit. The real Streamable HTTP transport does not emit onclose for network failures. A POST SSE response that ends cleanly without a JSON-RPC response can also remain pending until the SDK request timeout; that SDK-level behavior is outside this observability patch.

## Testing

- pnpm test
- bridge regression test verifies hosted and stdio errors are written to stderr