### PR TITLE
fix(server): deprecate query-string API keys and add telemetry (#27)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -413,7 +413,7 @@ export function createMcpServer(auth: AuthSource): McpServer {
                 type: 'text' as const,
                 text:
                     'Not authenticated. Sign in via OAuth, or provide an API key via ' +
-                    '?apiKey=YOUR_KEY query param, x-api-key header, or Authorization: Bearer am_... ' +
+                    'x-api-key header or Authorization: Bearer am_... ' +
                     'Get an API key at https://console.agentmail.to.',
             },
         ],
@@ -690,6 +690,9 @@ function sendOAuthChallenge(req: express.Request, res: express.Response) {
 }
 
 const authRouter: express.RequestHandler = async (req, res, next) => {
+    if (req.query.apiKey) {
+        console.warn('[telemetry] Legacy query-string API key auth used (sunset scheduled)')
+    }
     const apiKey = extractApiKey(req)
     if (apiKey) {
         req.authSource = { kind: 'apiKey', apiKey }


### PR DESCRIPTION
## Summary

Addresses #27 by starting the sunset phase for legacy query-string API keys (`?apiKey=...`) on the MCP server endpoint and promoting header-based authentication.

## Changes Made

- **Updated `noAuthMessage`**: Removed `?apiKey=YOUR_KEY` from unauthenticated server response messages. Instructs clients to use `x-api-key` header or `Authorization: Bearer am_...`.
- **Added Telemetry Logging**: Added a value-free warning log (`[telemetry] Legacy query-string API key auth used (sunset scheduled)`) in `authRouter` whenever `req.query.apiKey` is present to monitor legacy usage prior to total removal.

## Related Issues
Closes #27