### PR TITLE
Fix ChatGPT OAuth DCR default scopes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,6 +4,22 @@ The production endpoint is `https://mcp.agentmail.to/mcp`. Preserve the existing
 
 Before promotion, record real baseline health, latency, authenticated completion, and tool-call success. Verify `/health`, OAuth discovery, a direct authenticated read, a representative write, npm stdio, PyPI stdio, and the runtime contract.
 
+## Clerk OAuth configuration
+
+The hosted server advertises `openid`, `email`, and `profile` through protected-resource metadata. Some clients, including ChatGPT, omit `scope` during dynamic client registration and rely on Clerk's instance defaults. Production must therefore keep all of these settings:
+
+- Dynamic OAuth client registration enabled
+- JWT access tokens enabled
+- Default scopes containing `openid`, `email`, and `profile`
+
+Check an instance without changing it:
+
+```bash
+CLERK_SECRET_KEY=sk_live_... pnpm check:oauth-config
+```
+
+Changing the defaults only fixes future registrations. Existing OAuth applications that were registered without `openid` must be updated to include it or re-registered; otherwise Clerk rejects ChatGPT's authorization request with `invalid_scope`.
+
 Keep human GET navigation separate from MCP protocol traffic. Human pages may redirect to documentation. Authenticated MCP POST requests must stay on the same runtime or be served by a protocol alias, not redirected across origins.
 
 The deployment provider is an implementation detail. Operational alerts and dashboards should identify the AgentMail hosted MCP, repository commit, and production project revision.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "start": "pnpm --filter @agentmail/mcp-server start",
         "generate:manifest": "pnpm --filter @agentmail/mcp-server build && node scripts/generate-manifest.mjs",
         "check:bridges": "node scripts/check-bridge-boundaries.mjs",
+        "check:oauth-config": "node scripts/check-clerk-oauth-settings.mjs",
         "check:contract": "pnpm --filter @agentmail/mcp-server build && node scripts/check-contract.mjs",
         "test:python": "uv run --no-project --with ./python/stdio-bridge --with pytest pytest -q python/stdio-bridge/tests",
         "test": "pnpm check:contract && pnpm --filter agentmail-mcp test && node --test tests/*.test.mjs && pnpm test:python && pnpm check:bridges"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -928,12 +928,15 @@ app.all('/', statelessMethodGuard, authRouter, mcpHandler)
 // OAuth discovery metadata endpoints. Only mounted when Clerk is configured.
 if (CLERK_ENABLED) {
     // Advertise the identity scopes supported by Clerk. `openid` is required
-    // by ChatGPT's OAuth client and must be included during DCR so Clerk allows
-    // it on the subsequent authorization request. We deliberately do NOT
-    // advertise `user:org:read`: Clerk grants dynamically-registered (DCR) clients only
-    // `email offline_access profile`, so any DCR client (Cursor, Codex, etc.)
-    // that requested the advertised user:org:read was rejected with
-    // invalid_scope at consent — broken OAuth onboarding since 2026-05-08.
+    // by ChatGPT's OAuth client. Some DCR clients omit `scope` when registering,
+    // so Clerk's instance-level DCR defaults must also include openid, email,
+    // and profile; otherwise the later authorization request fails with
+    // invalid_scope. Verify the Clerk setting with `pnpm check:oauth-config`.
+    //
+    // We deliberately do NOT advertise `user:org:read`: dynamically registered
+    // clients are not granted it by default, so advertising it caused clients
+    // (Cursor, Codex, etc.) to request a scope that Clerk rejected at consent —
+    // broken OAuth onboarding since 2026-05-08.
     //
     // Multi-org users no longer need the Clerk consent-screen org picker (which
     // required user:org:read): they pick their org in-session via the

--- a/scripts/check-clerk-oauth-settings.mjs
+++ b/scripts/check-clerk-oauth-settings.mjs
@@ -1,0 +1,47 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SETTINGS_URL = 'https://api.clerk.com/v1/instance/oauth_application_settings'
+const REQUIRED_DEFAULT_SCOPES = ['openid', 'email', 'profile']
+
+export function validateClerkOAuthSettings(settings) {
+  const errors = []
+
+  if (settings.dynamic_oauth_client_registration !== true) {
+    errors.push('dynamic OAuth client registration is disabled')
+  }
+  if (settings.oauth_jwt_access_tokens !== true) {
+    errors.push('OAuth JWT access tokens are disabled')
+  }
+
+  const defaultScopes = Array.isArray(settings.default_scopes) ? settings.default_scopes : []
+  const missingScopes = REQUIRED_DEFAULT_SCOPES.filter((scope) => !defaultScopes.includes(scope))
+  if (missingScopes.length > 0) {
+    errors.push(`default scopes are missing: ${missingScopes.join(', ')}`)
+  }
+
+  return errors
+}
+
+async function main() {
+  const secretKey = process.env.CLERK_SECRET_KEY
+  if (!secretKey) throw new Error('CLERK_SECRET_KEY is required')
+
+  const response = await fetch(SETTINGS_URL, {
+    headers: { authorization: `Bearer ${secretKey}` },
+  })
+  if (!response.ok) {
+    throw new Error(`Clerk OAuth settings request failed with HTTP ${response.status}`)
+  }
+
+  const errors = validateClerkOAuthSettings(await response.json())
+  if (errors.length > 0) {
+    throw new Error(`Invalid Clerk OAuth settings: ${errors.join('; ')}`)
+  }
+
+  console.log('Clerk OAuth settings OK: DCR and JWT access tokens enabled; required defaults present')
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  await main()
+}

--- a/tests/clerk-oauth-settings.test.mjs
+++ b/tests/clerk-oauth-settings.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { validateClerkOAuthSettings } from '../scripts/check-clerk-oauth-settings.mjs'
+
+test('accepts the required Clerk OAuth settings', () => {
+  assert.deepEqual(
+    validateClerkOAuthSettings({
+      dynamic_oauth_client_registration: true,
+      oauth_jwt_access_tokens: true,
+      default_scopes: ['profile', 'openid', 'email'],
+    }),
+    [],
+  )
+})
+
+test('reports settings that would break ChatGPT OAuth', () => {
+  assert.deepEqual(
+    validateClerkOAuthSettings({
+      dynamic_oauth_client_registration: false,
+      oauth_jwt_access_tokens: false,
+      default_scopes: ['email', 'profile'],
+    }),
+    [
+      'dynamic OAuth client registration is disabled',
+      'OAuth JWT access tokens are disabled',
+      'default scopes are missing: openid',
+    ],
+  )
+})
+
+test('reports unset default scopes from the production regression', () => {
+  assert.deepEqual(
+    validateClerkOAuthSettings({
+      dynamic_oauth_client_registration: true,
+      oauth_jwt_access_tokens: true,
+      default_scopes: null,
+    }),
+    ['default scopes are missing: openid, email, profile'],
+  )
+})


### PR DESCRIPTION
## Summary

- document the Clerk DCR settings required by the hosted MCP OAuth metadata
- add a read-only check for DCR, JWT access tokens, and the openid/email/profile defaults
- cover the unset-default-scopes production regression with tests

## Root cause

ChatGPT can omit scope during dynamic client registration. With Clerk default_scopes unset, registrations lacked openid; the later authorization request included the advertised openid scope and Clerk rejected it with invalid_scope.

The production Clerk defaults and the 44 affected registrations were repaired separately. All 45 existing ChatGPT registrations now include openid.

Support reference: T-754

## Verification

- pnpm test
- pnpm check:oauth-config against production