### PR TITLE
Pin the toolkit at 0.6.1 so plan-cap errors reach the model

### DIFF
--- a/mcp-manifest.json
+++ b/mcp-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "server": "to.agentmail/agentmail",
   "endpoint": "https://mcp.agentmail.to/mcp",
-  "digest": "sha256:b4ddde565ed29ab7389e3024cc5df1f2347408eb5c8dff3b9459de9131056f45",
+  "digest": "sha256:cc6205d6d5be72d88d155943ee924b2230a1fb89b517b02e0f81bd006bb43b1f",
   "tools": [
     {
       "name": "list_inboxes",
@@ -3419,6 +3419,49 @@
         "readOnlyHint": false,
         "destructiveHint": true,
         "idempotentHint": true,
+        "openWorldHint": false
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      },
+      "oauthOnly": false
+    },
+    {
+      "name": "agent_verify",
+      "title": "Agent Verify",
+      "description": "Verify an unverified agent organization using the 6-digit code emailed to the human who signed up, lifting the unverified plan's caps (1 inbox, 10 sends/day) at no cost. Call this when a plan-cap error tells you to verify — ask your human for the code from their email. The code expires after 24 hours and allows at most 10 attempts.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "otpCode": {
+            "type": "string",
+            "description": "6-digit verification code emailed to the human who signed up"
+          }
+        },
+        "required": [
+          "otpCode"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "verified": {
+            "type": "boolean",
+            "description": "Whether the organization was verified"
+          }
+        },
+        "required": [
+          "verified"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "title": "Agent Verify",
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
         "openWorldHint": false
       },
       "execution": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "@clerk/mcp-tools": "0.3.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "agentmail": "0.5.14",
-    "agentmail-toolkit": "0.6.0",
+    "agentmail-toolkit": "0.6.1",
     "cors": "2.8.5",
     "express": "5.2.1",
     "jose": "5.9.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: ^3.1.5
+  ip-address: ^10.3.1
+
 importers:
 
   .:
@@ -327,8 +331,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -386,8 +390,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -795,7 +799,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -887,7 +891,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.5.0
 
   express@5.2.1:
     dependencies:
@@ -926,7 +930,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -991,7 +995,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 0.5.14
         version: 0.5.14
       agentmail-toolkit:
-        specifier: 0.6.0
-        version: 0.6.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+        specifier: 0.6.1
+        version: 0.6.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -174,8 +174,8 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  agentmail-toolkit@0.6.0:
-    resolution: {integrity: sha512-WoRwa2fJhaeDPFWNFc5n79ov6Fn5ogg06EQFd0Xd6yJqSF3u+n2/9WVGhDpmzZEpGTyyYWkVf8PVXtsXcm1YoQ==}
+  agentmail-toolkit@0.6.1:
+    resolution: {integrity: sha512-tAjvLonnOcNQFUnaNTWRLQFK2JrD7uZUjhlw6irhil4c+xgpVTPuG9JyIrED2Syf9GPYFdhJcghm653eDOQ2Yw==}
     peerDependencies:
       '@mariozechner/pi-agent-core': ^0.50.1
       '@modelcontextprotocol/sdk': ^1.24.1
@@ -768,7 +768,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agentmail-toolkit@0.6.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)):
+  agentmail-toolkit@0.6.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)):
     dependencies:
       agentmail: 0.5.14
       jszip: 3.10.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,16 @@
 packages:
   - packages/*
 
+# Both are transitive under @modelcontextprotocol/sdk and both patches sit inside the ranges its
+# deps already declare (ajv wants fast-uri ^3.0.1, express-rate-limit wants ip-address ^10.2.0),
+# so this pins the floor rather than forcing an incompatible version. Without it a future
+# lockfile refresh can resolve back down into the vulnerable range.
+#   fast-uri   <3.1.5   GHSA-7p8r-x3mc-p8w7  host confusion via backslash authority introducer
+#   ip-address <10.3.1  GHSA-mwp4-54f8-5fhr  leading-zero octet decoding, SSRF / trust-boundary bypass
+overrides:
+  fast-uri: ^3.1.5
+  ip-address: ^10.3.1
+
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - agentmail

--- a/tests/server-contract.test.mjs
+++ b/tests/server-contract.test.mjs
@@ -30,6 +30,13 @@ const coreTools = [
   'update_draft',
   'send_draft',
   'delete_draft',
+  // agent_verify is in the hosted catalog on purpose. An agent that signed up
+  // through /v0/agent/sign-up authenticates here with the key that call returned,
+  // and the API now answers its plan-cap errors with "ask your human for the code
+  // and call /v0/agent/verify" — a remedy it cannot perform without this tool. It
+  // takes an OTP code and returns { verified }, so the identifier concern that
+  // keeps auth_me out does not apply.
+  'agent_verify',
   // auth_me is deliberately absent: excluded from the hosted catalog only
   // (organization/pod/API-key identifiers are unnecessary on the OpenAI
   // surface); it remains available in agentmail-toolkit for other consumers.


### PR DESCRIPTION
## Why

Two merged changes are currently invisible to every MCP agent, and this pin is the only reason.

- [`agentmail-api#834`](https://github.com/agentmail-to/agentmail-api/pull/834) made plan-cap and send-quota errors self-describing — the body carries a `fix` naming the cap, the window it resets in, and the tier that raises it with its price.
- [`agentmail-toolkit#50`](https://github.com/agentmail-to/agentmail-toolkit/pull/50) stopped this server's error formatter from throwing that away.

This server resolves `agentmail-toolkit@0.6.0`, which does neither.

## What an agent sees today

```
Inbox limit exceeded (HTTP 403) — the authenticated credential lacks permission for this action
```

The `fix` is dropped, and the canned 403 line replaces it with a wrong diagnosis. A model told its credential lacks permission retries with different credentials or gives up — it does not tell its human to upgrade. The 429 line is wrong the same way: "wait before retrying" does not terminate against a monthly quota.

## After

```
Inbox limit exceeded — Your plan's inbox limit is 3. Delete an existing inbox, or upgrade at
https://console.agentmail.to/dashboard/upgrade — Developer raises it to 10 for $20.00/month. (HTTP 403)
```

## `agent_verify` joins the hosted catalog

0.6.1 adds it. The new agent-plan copy tells an unverified org to ask its human for the emailed code and call `POST /v0/agent/verify`, and no tool exposed it — the remedy was stated and unperformable. An agent that signed up through `/v0/agent/sign-up` authenticates here with the key that call returned, so this is a reachable path, not a hypothetical one.

It takes an OTP code and returns `{ verified }`, so the unnecessary-internal-identifier objection that keeps `auth_me` out of the hosted catalog does not apply. Manifest and contract test move with it.

(`agent_sign_up` was deliberately left out of 0.6.1: this server 401s before any tool runs without a credential, so it could never be called.)

## Also: the two high advisories

`pnpm audit --prod --audit-level high` has failed on `main` since **2026-08-04**, unrelated to this change but fixed here rather than left red.

| Package | Advisory | |
|---|---|---|
| `fast-uri` <3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | host confusion via backslash authority introducer |
| `ip-address` <10.3.1 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) | leading-zero octets decoded as decimal — SSRF / trust-boundary bypass |

Both transitive under `@modelcontextprotocol/sdk`, and neither needed a version the tree could not already take — ajv declares `fast-uri ^3.0.1`, express-rate-limit declares `ip-address ^10.2.0`. The lockfile was simply holding an older resolution. The overrides raise the floor so a later refresh cannot fall back into the vulnerable range.

Worth knowing: **pnpm 10 ignores `overrides` in `package.json`** and warns about it. The ignored form still *appears* to work, because the resolution moves for an unrelated reason — the guard just is not there. These live in `pnpm-workspace.yaml`.

Remaining: 1 low, 4 moderate, all below the check's threshold.

## Scope

`packages/server/package.json`, `pnpm-workspace.yaml`, the lockfile, the generated manifest, and the contract test. `agentmail-toolkit@0.6.1` is published to npm.

**This needs a redeploy to take effect** — the merge alone changes nothing for a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)