### PR TITLE
Pin patched Hono transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,6 @@
         "test:python": "uv run --no-project --with ./python/stdio-bridge --with pytest pytest -q python/stdio-bridge/tests",
         "test": "pnpm check:contract && pnpm --filter agentmail-mcp test && node --test tests/*.test.mjs && pnpm test:python && pnpm check:bridges"
     },
-    "pnpm": {
-        "overrides": {
-            "@hono/node-server": "1.19.15",
-            "fast-uri": "^3.1.5",
-            "ip-address": "^10.3.1",
-            "hono": "4.12.34"
-        }
-    },
     "devDependencies": {
         "@modelcontextprotocol/sdk": "1.29.0"
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
         "test:python": "uv run --no-project --with ./python/stdio-bridge --with pytest pytest -q python/stdio-bridge/tests",
         "test": "pnpm check:contract && pnpm --filter agentmail-mcp test && node --test tests/*.test.mjs && pnpm test:python && pnpm check:bridges"
     },
+    "pnpm": {
+        "overrides": {
+            "@hono/node-server": "1.19.15",
+            "fast-uri": "^3.1.5",
+            "ip-address": "^10.3.1",
+            "hono": "4.12.34"
+        }
+    },
     "devDependencies": {
         "@modelcontextprotocol/sdk": "1.29.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@hono/node-server': 1.19.15
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
+  hono: 4.12.34
 
 importers:
 
@@ -116,11 +118,11 @@ packages:
       react-dom:
         optional: true
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+  '@hono/node-server@1.19.15':
+    resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -372,8 +374,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.30:
-    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -686,13 +688,13 @@ snapshots:
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.7
 
-  '@hono/node-server@1.19.14(hono@4.12.30)':
+  '@hono/node-server@1.19.15(hono@4.12.34)':
     dependencies:
-      hono: 4.12.30
+      hono: 4.12.34
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.30)
+      '@hono/node-server': 1.19.15(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -702,7 +704,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.30
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -977,7 +979,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.30: {}
+  hono@4.12.34: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@hono/node-server': 1.19.15
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
-  hono: 4.12.34
+  hono: ^4.12.34
+  '@hono/node-server': ^1.19.15
 
 importers:
 
@@ -122,7 +122,7 @@ packages:
     resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: ^4.12.34
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,19 @@ packages:
 # lockfile refresh can resolve back down into the vulnerable range.
 #   fast-uri   <3.1.5   GHSA-7p8r-x3mc-p8w7  host confusion via backslash authority introducer
 #   ip-address <10.3.1  GHSA-mwp4-54f8-5fhr  leading-zero octet decoding, SSRF / trust-boundary bypass
+#
+# The hono pair is the same shape: the sdk declares hono ^4.11.4 and @hono/node-server ^1.19.9, so
+# both floors sit inside its ranges. @hono/node-server is loaded at runtime by the sdk's
+# streamableHttp transport, so these are in the deployed tree, not dev-only.
+#   hono              <4.12.34  GHSA-f23p-vx2j-j53r  memo() retains SSR output across requests
+#                               GHSA-54fx-42gc-7vw4  algorithmic-complexity DoS in language middleware
+#                               GHSA-8j4g-w8fx-2239  ReDoS in CORS middleware via ACRH
+#   @hono/node-server <1.19.15  GHSA-frvp-7c67-39w9  serve-static path traversal on Windows
 overrides:
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
+  hono: ^4.12.34
+  '@hono/node-server': ^1.19.15
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Summary
- pin Hono to 4.12.34 and @hono/node-server to 1.19.15
- preserve the existing fast-uri and ip-address security overrides
- clear the three current medium Dependabot findings for this repository

## Verification
- pnpm install --frozen-lockfile
- pnpm audit --audit-level medium (no known vulnerabilities)
- pnpm build
- pnpm test (22 Node tests and 4 Python tests pass)