### PR TITLE
Shed load instead of queueing it

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,9 +41,26 @@ server or a Clerk verification:
   secondary bound on the live set, since every in-flight request pins a whole
   McpServer, transport, and req/res.
 
-`AGENTMAIL_REQUEST_TIMEOUT_MS` (default 30000) returns `504` and releases the slot
-for any request that would otherwise hold one indefinitely.
+Ordering matters as much as the limits. Clerk authentication and JSON body
+parsing are mounted *inside* the MCP pipeline, after the admission gate, not as
+globals. As globals every request paid both before it could be shed, which is the
+cost shedding exists to avoid and the cost that accumulates during a retry storm.
+
+`AGENTMAIL_REQUEST_TIMEOUT_MS` (default 30000) reclaims any request that would
+otherwise hold a slot indefinitely. Before headers go out it returns `504`. Once
+they have, it destroys the connection instead — `StreamableHTTPServerTransport`
+writes SSE headers before a `tools/call` handler settles, so every hung tool call
+is already past the point where a status can be sent, and a timeout that merely
+returned there would be a no-op for exactly the requests that need it.
+
 `AGENTMAIL_SHED_RETRY_AFTER_SECONDS` (default 2) sets the `Retry-After` value.
+
+A slot is held until the handler settles, not until the client disconnects, and
+the MCP request's abort signal is injected into the AgentMail SDK through a custom
+`fetch`. agentmail-toolkit does not forward `extra.signal`, so without that a
+client abort left the upstream HTTP request running to completion while the server
+reported zero in flight — letting timed-out clients rebuild unbounded background
+work behind a cap that looked healthy.
 
 Shedding is self-healing: it clears as soon as the next sample is under the
 limits, and logs only the transitions, never the individual sheds.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,3 +25,30 @@ Keep human GET navigation separate from MCP protocol traffic. Human pages may re
 The deployment provider is an implementation detail. Operational alerts and dashboards should identify the AgentMail hosted MCP, repository commit, and production project revision.
 
 Authentication hardening is a separate rollout. This migration preserves the current hosted inputs and observable behavior.
+
+## Overload protection
+
+The server sheds load instead of queueing it. Two independent triggers, either of
+which returns `503` with `Retry-After` before the request costs a per-request MCP
+server or a Clerk verification:
+
+- Event loop lag above `AGENTMAIL_MAX_EVENT_LOOP_LAG_MS` (default 500). This is
+  the primary trigger. Under saturation a request waits in the kernel and libuv
+  queues long before Express routes it, so an in-flight counter reads low while
+  real latency is already seconds — measuring the loop catches the backlog
+  wherever it sits.
+- In-flight requests at or above `AGENTMAIL_MAX_IN_FLIGHT` (default 256). A
+  secondary bound on the live set, since every in-flight request pins a whole
+  McpServer, transport, and req/res.
+
+`AGENTMAIL_REQUEST_TIMEOUT_MS` (default 30000) returns `504` and releases the slot
+for any request that would otherwise hold one indefinitely.
+`AGENTMAIL_SHED_RETRY_AFTER_SECONDS` (default 2) sets the `Retry-After` value.
+
+Shedding is self-healing: it clears as soon as the next sample is under the
+limits, and logs only the transitions, never the individual sheds.
+
+Watch `requests` in `/health` — `in_flight`, `event_loop_lag_ms`, and `shed_total`.
+Note that `https://mcp.agentmail.to/health` is answered by the Manufact gateway and
+never reaches the app, so it stays green during an outage. Probe the app's own
+`/health` on the deployment's `.fly.dev` host, or an MCP `ping`, for real signal.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -303,7 +303,8 @@ async function setStoredMcpOrgId(clerkUserId: string, orgId: string): Promise<vo
  */
 async function buildClientFromClerkUser(
     clerkUserId: string,
-    selectedClerkOrgId?: string
+    selectedClerkOrgId?: string,
+    signal?: AbortSignal
 ): Promise<AgentMailClient> {
     const memberships = await clerkClient.users.getOrganizationMembershipList({
         userId: clerkUserId,
@@ -362,18 +363,45 @@ async function buildClientFromClerkUser(
             ? { http: AGENTMAIL_API_URL, websockets: AGENTMAIL_WS_URL || '' }
             : undefined,
         apiKey: consoleJwt,
+        fetch: fetchBoundTo(signal),
     })
+}
+
+/**
+ * Wrap fetch so every AgentMail request inherits the MCP request's cancellation.
+ *
+ * agentmail-toolkit does not forward `extra.signal` into the SDK, so without
+ * this a client that disconnects leaves its AgentMail HTTP request running to
+ * completion. That is invisible work: the connection is gone, nothing will read
+ * the response, and the retry the client just issued adds another one on top.
+ * Measured directly — after aborting a streamed tool call, the upstream socket
+ * stayed open indefinitely while the server reported zero in flight.
+ *
+ * The SDK takes a custom `fetch` at construction and we build a client per tool
+ * call, so injecting the signal here reaches every request the toolkit makes
+ * without the toolkit having to cooperate.
+ */
+function fetchBoundTo(signal: AbortSignal | undefined): typeof fetch | undefined {
+    if (!signal) return undefined
+    return (input, init) => {
+        const callerSignal = init?.signal
+        return fetch(input, {
+            ...init,
+            signal: callerSignal ? AbortSignal.any([callerSignal, signal]) : signal,
+        })
+    }
 }
 
 /**
  * Build an AgentMailClient from a raw API key (legacy path).
  */
-function buildClientFromApiKey(apiKey: string): AgentMailClient {
+function buildClientFromApiKey(apiKey: string, signal?: AbortSignal): AgentMailClient {
     return new AgentMailClient({
         environment: AGENTMAIL_API_URL
             ? { http: AGENTMAIL_API_URL, websockets: AGENTMAIL_WS_URL || '' }
             : undefined,
         apiKey,
+        fetch: fetchBoundTo(signal),
     })
 }
 
@@ -428,9 +456,13 @@ export function createMcpServer(auth: AuthSource): McpServer {
             try {
                 let client: AgentMailClient
                 if (auth.kind === 'clerk') {
-                    client = await buildClientFromClerkUser(auth.clerkUserId, auth.clerkOrgId)
+                    client = await buildClientFromClerkUser(
+                        auth.clerkUserId,
+                        auth.clerkOrgId,
+                        extra?.signal
+                    )
                 } else if (auth.kind === 'apiKey') {
-                    client = buildClientFromApiKey(auth.apiKey)
+                    client = buildClientFromApiKey(auth.apiKey, extra?.signal)
                 } else {
                     return noAuthMessage
                 }
@@ -845,7 +877,7 @@ app.set('trust proxy', true)
 app.use(publicUrlOverride)
 
 app.use(cors({ exposedHeaders: ['WWW-Authenticate'] }))
-app.use(clerkAuthBoundary)
+
 // Match the AgentMail API's inbound ceiling exactly. The API runs on API
 // Gateway v2 (HTTP API), whose max request body is a hard, non-configurable
 // 10 MB (agentmail-api infra/core/gateway.ts uses apigatewayv2.Api with no
@@ -854,7 +886,18 @@ app.use(clerkAuthBoundary)
 // large tool calls before they reach the MCP handler; anything above 10 MB is
 // rejected downstream by API Gateway regardless, so matching is correct.
 const MAX_REQUEST_BODY = '10mb'
-app.use(express.json({ limit: MAX_REQUEST_BODY }))
+const parseJsonBody = express.json({ limit: MAX_REQUEST_BODY })
+
+// clerkAuthBoundary and body parsing are deliberately NOT app.use'd. As globals
+// they ran before the MCP routes, so a request paid Clerk authentication and up
+// to 10 MB of JSON parsing BEFORE admission control could see it — which is
+// exactly the cost a shed is supposed to avoid, and exactly the cost that
+// accumulates without bound during the retry storm this guards against. Both are
+// mounted inside the MCP pipeline below, after the admission gate.
+//
+// Nothing else needs them: /health and the openai-apps challenge read no body
+// and no auth, and the OAuth metadata handlers compose their response from the
+// publishable key and the request URL alone.
 
 // OpenAI app ownership verification. This token is public by design and must
 // be returned verbatim from the origin-root well-known URL.
@@ -949,6 +992,17 @@ setInterval(() => {
     loopDelay.reset()
 }, LAG_SAMPLE_INTERVAL_MS).unref()
 
+/**
+ * One admitted request's hold on the in-flight cap. `ownedByHandler` transfers
+ * responsibility for releasing it from the connection lifecycle to mcpHandler,
+ * so a client that walks away cannot free capacity that is still in use.
+ */
+type AdmissionSlot = { release: () => void; ownedByHandler: boolean }
+
+function admissionSlotOf(res: express.Response): AdmissionSlot | undefined {
+    return res.locals.admissionSlot as AdmissionSlot | undefined
+}
+
 let inFlight = 0
 let shedTotal = 0
 // Log the transition, not the event: at overload the shed rate is exactly the
@@ -983,25 +1037,47 @@ export const admissionControl: express.RequestHandler = (req, res, next) => {
         return
     }
 
-    inFlight++
-    // 'close' always fires, on clean finish and on client abort alike, so one
-    // listener covers both. Guard against a double release: Express can emit
-    // 'close' after 'finish', and releasing twice would let in-flight drift
-    // below zero, silently raising the effective cap.
+    // Guard against a double release: Express can emit 'close' after 'finish',
+    // and releasing twice would let in-flight drift below zero, silently
+    // raising the effective cap.
     let released = false
-    const release = () => {
-        if (released) return
-        released = true
-        inFlight--
-        if (shedding && !overloadReason()) {
-            shedding = false
-            console.warn(
-                `[admission] recovered: ${inFlight} in flight, ` +
-                    `${Math.round(recentLagMs)} ms loop lag, ${shedTotal} shed so far`
-            )
-        }
+    const slot: AdmissionSlot = {
+        ownedByHandler: false,
+        release: () => {
+            if (released) return
+            released = true
+            inFlight--
+            if (shedding && !overloadReason()) {
+                shedding = false
+                console.warn(
+                    `[admission] recovered: ${inFlight} in flight, ` +
+                        `${Math.round(recentLagMs)} ms loop lag, ${shedTotal} shed so far`
+                )
+            }
+        },
     }
-    res.on('close', release)
+    res.locals.admissionSlot = slot
+
+    // A client abort must NOT free the slot while the handler is still working.
+    // transport.close() only aborts the MCP-level signal; agentmail-toolkit
+    // ignores extra.signal, so the AgentMail HTTP request it started keeps
+    // running. Releasing on abort would let a timed-out client immediately retry
+    // into a fresh slot and stack a second live upstream call behind a cap that
+    // reads healthy — rebuilding exactly the unbounded background concurrency
+    // this is meant to bound.
+    //
+    // So 'close' only releases for requests that never reached mcpHandler (405,
+    // a 401 from authRouter, a body-parse failure). Once the handler takes
+    // ownership it releases in its own finally, and requestTimeout is the
+    // backstop for work that never settles at all.
+    res.on('close', () => {
+        if (!slot.ownedByHandler) slot.release()
+    })
+
+    // Counted last, once the release path is fully wired. Incrementing earlier
+    // means anything that throws in between leaks a slot permanently, and enough
+    // leaks silently pin the server in shedding with nothing actually running.
+    inFlight++
     next()
 }
 
@@ -1020,13 +1096,29 @@ const REQUEST_TIMEOUT_MS = Math.max(
 
 export const requestTimeout: express.RequestHandler = (req, res, next) => {
     const timer = setTimeout(() => {
-        if (res.headersSent) return
-        console.warn(`[timeout] request exceeded ${REQUEST_TIMEOUT_MS} ms, returning 504`)
-        res.status(504).json({
-            jsonrpc: '2.0',
-            error: { code: -32000, message: 'Request timed out' },
-            id: null,
-        })
+        if (!res.headersSent) {
+            console.warn(`[timeout] request exceeded ${REQUEST_TIMEOUT_MS} ms, returning 504`)
+            res.status(504).json({
+                jsonrpc: '2.0',
+                error: { code: -32000, message: 'Request timed out' },
+                id: null,
+            })
+            return
+        }
+
+        // Headers are already out, so there is no status left to send — and
+        // returning here would make this timer a no-op for exactly the requests
+        // that need it most. StreamableHTTPServerTransport writes SSE headers
+        // before a tools/call handler settles, so every hung tool call lands in
+        // this branch: 'close' never fires on its own, the slot never comes
+        // back, and MAX_IN_FLIGHT hung calls would leave the server shedding
+        // permanently. Destroy the stream to force the connection down, and
+        // release explicitly rather than relying on teardown ordering.
+        console.warn(
+            `[timeout] streamed request exceeded ${REQUEST_TIMEOUT_MS} ms, destroying connection`
+        )
+        res.destroy()
+        admissionSlotOf(res)?.release()
     }, REQUEST_TIMEOUT_MS)
     // unref so a pending timer never holds the process open during shutdown.
     timer.unref()
@@ -1040,6 +1132,10 @@ export const requestTimeout: express.RequestHandler = (req, res, next) => {
 // are redirected to the docs above, all other GETs and DELETEs get a 405
 // from statelessMethodGuard.
 const mcpHandler: express.RequestHandler = async (req, res) => {
+    // Take the slot off the connection lifecycle: from here the request is only
+    // done when this handler settles, not when the client stops listening.
+    const slot = admissionSlotOf(res)
+    if (slot) slot.ownedByHandler = true
     try {
         const authSource = req.authSource ?? { kind: 'none' }
         const server = createMcpServer(authSource)
@@ -1056,6 +1152,9 @@ const mcpHandler: express.RequestHandler = async (req, res) => {
                 id: null,
             })
         }
+    } finally {
+        // Settled either way, so the capacity is genuinely free now.
+        slot?.release()
     }
 }
 
@@ -1066,11 +1165,20 @@ app.get(['/', '/mcp'], (req, res, next) => {
     res.redirect(302, DOCS_URL)
 })
 
-// MCP endpoints. statelessMethodGuard sheds GET/DELETE, admissionControl caps
-// concurrency and sheds the excess, requestTimeout guarantees slots come back,
-// then authRouter decides OAuth vs API key for the POSTs that remain. Auth runs
-// last on purpose: a shed request must not cost a Clerk token verification.
-const mcpPipeline = [statelessMethodGuard, admissionControl, requestTimeout, authRouter, mcpHandler]
+// MCP endpoints, ordered cheapest-first so an overloaded server spends as little
+// as possible on a request it is about to reject: statelessMethodGuard sheds
+// GET/DELETE, admissionControl caps concurrency, requestTimeout guarantees slots
+// come back, and only then does a request earn body parsing, Clerk
+// authentication, and a per-request MCP server.
+const mcpPipeline = [
+    statelessMethodGuard,
+    admissionControl,
+    requestTimeout,
+    parseJsonBody,
+    clerkAuthBoundary,
+    authRouter,
+    mcpHandler,
+]
 app.all('/mcp', ...mcpPipeline)
 app.all('/', ...mcpPipeline)
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { SignJWT } from 'jose'
 import crypto from 'node:crypto'
 import v8 from 'node:v8'
+import { monitorEventLoopDelay } from 'node:perf_hooks'
 import { z } from 'zod'
 
 // ============================================================================
@@ -888,6 +889,151 @@ const statelessMethodGuard: express.RequestHandler = (req, res, next) => {
         })
 }
 
+// ============================================================================
+// Admission control
+//
+// Every in-flight POST pins a whole per-request graph: a fresh McpServer with
+// all tools registered, a transport, and req/res. That is cheap in isolation
+// (~0.3 ms to build) and the box sustains hundreds of requests per second while
+// concurrency stays bounded. It stops being cheap when concurrency does not.
+//
+// The 2026-08-19 outage was that unbounded case. A latency blip pushed clients
+// into timeout-and-retry, retries raised concurrency, concurrency raised the
+// live set and GC cost, and the slower process produced more timeouts — a loop
+// that sustains itself at flat demand. Throughput fell from ~200 req/s to under
+// 10 while p50 passed 9 s, and it never recovered: redeploying onto a fresh
+// machine bought eight minutes before the retry backlog rebuilt the queue.
+// Capacity was never the limit — an idle machine on the same image serves 268
+// req/s against a 30-60 req/s demand — the missing piece was a ceiling.
+//
+// So we cap concurrency and shed the excess INSTANTLY. A fast 503 is strictly
+// better than a slow 200 here: it costs no per-request graph, it keeps the queue
+// short enough that admitted requests stay fast, and Retry-After pushes clients
+// into backoff instead of the tighter retry loop that a timeout provokes.
+// Shedding is what makes the feedback loop stop sustaining itself.
+//
+// Mounted after statelessMethodGuard (shed GETs must not consume a slot) and
+// before authRouter (a shed request must not cost a Clerk verification).
+// ============================================================================
+
+const MAX_IN_FLIGHT = Math.max(1, parseInt(process.env.AGENTMAIL_MAX_IN_FLIGHT || '', 10) || 256)
+const SHED_RETRY_AFTER_SECONDS = Math.max(
+    1,
+    parseInt(process.env.AGENTMAIL_SHED_RETRY_AFTER_SECONDS || '', 10) || 2
+)
+
+// Event loop lag is the signal that actually matches the observed failure, and
+// an in-flight counter alone would have missed it. When the loop is saturated a
+// request waits in the kernel and libuv queues LONG before Express routes it,
+// so by the time any middleware could increment a counter most of the latency
+// has already been spent — in-flight reads near zero while p50 is 9 s.
+// Measuring the loop catches the backlog wherever it sits, which is why this is
+// the primary trigger and the in-flight cap is only a secondary bound.
+//
+// Healthy lag here is single-digit to tens of milliseconds, so a mean of half a
+// second means the process is already deep in the queue-growth spiral.
+const MAX_EVENT_LOOP_LAG_MS = Math.max(
+    50,
+    parseInt(process.env.AGENTMAIL_MAX_EVENT_LOOP_LAG_MS || '', 10) || 500
+)
+const LAG_SAMPLE_INTERVAL_MS = 1000
+
+const loopDelay = monitorEventLoopDelay({ resolution: 20 })
+loopDelay.enable()
+let recentLagMs = 0
+// Mean over the window, not max: a single GC pause spikes max and would shed
+// traffic on a perfectly healthy server. Sustained saturation is what we react
+// to, and that is what shows up in the mean.
+setInterval(() => {
+    recentLagMs = loopDelay.mean / 1e6
+    loopDelay.reset()
+}, LAG_SAMPLE_INTERVAL_MS).unref()
+
+let inFlight = 0
+let shedTotal = 0
+// Log the transition, not the event: at overload the shed rate is exactly the
+// excess arrival rate, so per-request logging would itself become a load source.
+let shedding = false
+
+function overloadReason(): string | undefined {
+    if (recentLagMs > MAX_EVENT_LOOP_LAG_MS) {
+        return `event loop ${Math.round(recentLagMs)} ms behind (limit ${MAX_EVENT_LOOP_LAG_MS} ms)`
+    }
+    if (inFlight >= MAX_IN_FLIGHT) {
+        return `${inFlight} in flight at or above cap ${MAX_IN_FLIGHT}`
+    }
+    return undefined
+}
+
+export const admissionControl: express.RequestHandler = (req, res, next) => {
+    const reason = overloadReason()
+    if (reason) {
+        shedTotal++
+        if (!shedding) {
+            shedding = true
+            console.warn(`[admission] shedding: ${reason}`)
+        }
+        res.status(503)
+            .set('Retry-After', String(SHED_RETRY_AFTER_SECONDS))
+            .json({
+                jsonrpc: '2.0',
+                error: { code: -32000, message: 'Server overloaded, retry shortly' },
+                id: null,
+            })
+        return
+    }
+
+    inFlight++
+    // 'close' always fires, on clean finish and on client abort alike, so one
+    // listener covers both. Guard against a double release: Express can emit
+    // 'close' after 'finish', and releasing twice would let in-flight drift
+    // below zero, silently raising the effective cap.
+    let released = false
+    const release = () => {
+        if (released) return
+        released = true
+        inFlight--
+        if (shedding && !overloadReason()) {
+            shedding = false
+            console.warn(
+                `[admission] recovered: ${inFlight} in flight, ` +
+                    `${Math.round(recentLagMs)} ms loop lag, ${shedTotal} shed so far`
+            )
+        }
+    }
+    res.on('close', release)
+    next()
+}
+
+// A slot is only useful if it comes back. Two paths hold one open indefinitely:
+// a client that stops reading without resetting the connection, and the
+// contained-unhandled-rejection path above, where the request deliberately gets
+// no response. Without a ceiling those accumulate until the cap holds only dead
+// requests and every live one is shed — turning a slow outage into a total one.
+//
+// Ending the response makes 'close' fire, which releases the slot and runs the
+// same transport teardown as a client abort, reusing an already-exercised path.
+const REQUEST_TIMEOUT_MS = Math.max(
+    1000,
+    parseInt(process.env.AGENTMAIL_REQUEST_TIMEOUT_MS || '', 10) || 30_000
+)
+
+export const requestTimeout: express.RequestHandler = (req, res, next) => {
+    const timer = setTimeout(() => {
+        if (res.headersSent) return
+        console.warn(`[timeout] request exceeded ${REQUEST_TIMEOUT_MS} ms, returning 504`)
+        res.status(504).json({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'Request timed out' },
+            id: null,
+        })
+    }, REQUEST_TIMEOUT_MS)
+    // unref so a pending timer never holds the process open during shutdown.
+    timer.unref()
+    res.on('close', () => clearTimeout(timer))
+    next()
+}
+
 // MCP request handler. We don't use streamableHttpHandler here because it
 // pre-binds an MCP server; we want to construct ours per-request based on
 // the resolved auth source. Only POST reaches this handler: text/html GETs
@@ -920,10 +1066,13 @@ app.get(['/', '/mcp'], (req, res, next) => {
     res.redirect(302, DOCS_URL)
 })
 
-// MCP endpoints. statelessMethodGuard sheds GET/DELETE, then authRouter
-// decides OAuth vs API key for the POSTs that remain.
-app.all('/mcp', statelessMethodGuard, authRouter, mcpHandler)
-app.all('/', statelessMethodGuard, authRouter, mcpHandler)
+// MCP endpoints. statelessMethodGuard sheds GET/DELETE, admissionControl caps
+// concurrency and sheds the excess, requestTimeout guarantees slots come back,
+// then authRouter decides OAuth vs API key for the POSTs that remain. Auth runs
+// last on purpose: a shed request must not cost a Clerk token verification.
+const mcpPipeline = [statelessMethodGuard, admissionControl, requestTimeout, authRouter, mcpHandler]
+app.all('/mcp', ...mcpPipeline)
+app.all('/', ...mcpPipeline)
 
 // OAuth discovery metadata endpoints. Only mounted when Clerk is configured.
 if (CLERK_ENABLED) {
@@ -964,6 +1113,18 @@ app.get('/health', (_req, res) => {
             used_mb: Math.round(heapUsed / MB),
             limit_mb: Math.round(HEAP_LIMIT_BYTES / MB),
             rss_mb: Math.round(rss / MB),
+        },
+        // Concurrency, not memory, is what fails on this server. The Aug 19
+        // outage ran at a healthy 74-92 MB heap the whole time, so the heap
+        // block above stayed green while the queue was thousands deep. These
+        // are the leading indicators: event_loop_lag_ms approaching the limit
+        // is the collapse starting, a climbing shed_total is it in progress.
+        requests: {
+            in_flight: inFlight,
+            max_in_flight: MAX_IN_FLIGHT,
+            shed_total: shedTotal,
+            event_loop_lag_ms: Math.round(recentLagMs),
+            max_event_loop_lag_ms: MAX_EVENT_LOOP_LAG_MS,
         },
     })
 })

--- a/tests/server-admission.test.mjs
+++ b/tests/server-admission.test.mjs
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { EventEmitter } from 'node:events'
+
+process.env.AGENTMAIL_MCP_NO_LISTEN = '1'
+// Both are read once at module load, so they have to be set before the import.
+// A cap of 2 is enough to exercise admit/shed/release without needing timing.
+process.env.AGENTMAIL_MAX_IN_FLIGHT = '2'
+// Floored at 1000 ms by the implementation, so this is the fastest a timeout
+// test can run.
+process.env.AGENTMAIL_REQUEST_TIMEOUT_MS = '1000'
+process.env.AGENTMAIL_MAX_EVENT_LOOP_LAG_MS = '300'
+const { app, admissionControl, requestTimeout } = await import('../packages/server/build/index.js')
+
+/** Minimal stand-in for an Express response: records what the middleware did. */
+function mockRes() {
+    const res = new EventEmitter()
+    res.statusCode = undefined
+    res.headers = {}
+    res.body = undefined
+    res.headersSent = false
+    res.status = (code) => {
+        res.statusCode = code
+        return res
+    }
+    res.set = (key, value) => {
+        res.headers[typeof key === 'object' ? Object.keys(key)[0] : key] =
+            typeof key === 'object' ? Object.values(key)[0] : value
+        return res
+    }
+    res.json = (payload) => {
+        res.body = payload
+        res.headersSent = true
+        return res
+    }
+    return res
+}
+
+function admit() {
+    const res = mockRes()
+    let passed = false
+    admissionControl({}, res, () => {
+        passed = true
+    })
+    return { res, passed }
+}
+
+test('admission control admits up to the cap and sheds the excess instantly', () => {
+    const first = admit()
+    const second = admit()
+    assert.equal(first.passed, true)
+    assert.equal(second.passed, true)
+
+    // Third request is over the cap. It must be rejected without reaching the
+    // next handler at all: the whole point is that a shed request costs no
+    // per-request graph and no Clerk verification.
+    const third = admit()
+    assert.equal(third.passed, false)
+    assert.equal(third.res.statusCode, 503)
+
+    // Retry-After is what converts a shed into client backoff. Without it a
+    // client is free to retry immediately, which is the loop we are breaking.
+    assert.ok(Number(third.res.headers['Retry-After']) >= 1)
+    assert.equal(third.res.body.jsonrpc, '2.0')
+    assert.equal(third.res.body.error.code, -32000)
+    assert.match(third.res.body.error.message, /overloaded/i)
+
+    first.res.emit('close')
+    second.res.emit('close')
+})
+
+test('a finished request returns its slot', () => {
+    const first = admit()
+    const second = admit()
+    assert.equal(admit().passed, false, 'cap reached')
+
+    first.res.emit('close')
+
+    const afterRelease = admit()
+    assert.equal(afterRelease.passed, true, 'freed slot is reusable')
+
+    second.res.emit('close')
+    afterRelease.res.emit('close')
+})
+
+test('a double close does not release the same slot twice', () => {
+    const first = admit()
+    const second = admit()
+
+    // Express can emit 'close' after 'finish'. If that double-counted, in-flight
+    // would drift below zero and the effective cap would grow without bound —
+    // silently disabling admission control exactly when it is needed.
+    first.res.emit('close')
+    first.res.emit('close')
+
+    const third = admit()
+    assert.equal(third.passed, true, 'one slot was freed')
+    const fourth = admit()
+    assert.equal(fourth.passed, false, 'cap still 2, not 3')
+
+    second.res.emit('close')
+    third.res.emit('close')
+})
+
+test('a request that never responds is timed out so its slot comes back', async () => {
+    const res = mockRes()
+    // next() is intentionally a no-op: this models the contained-unhandled-
+    // rejection path, where the request deliberately gets no response and would
+    // otherwise pin its slot until the client gave up.
+    requestTimeout({}, res, () => {})
+
+    await new Promise((resolve) => setTimeout(resolve, 1300))
+
+    assert.equal(res.statusCode, 504)
+    assert.equal(res.body.error.code, -32000)
+    assert.match(res.body.error.message, /timed out/i)
+})
+
+test('a saturated event loop sheds even while in-flight is zero', async (t) => {
+    const server = app.listen(0)
+    t.after(() => server.close())
+    await new Promise((resolve) => server.once('listening', resolve))
+    const { port } = server.address()
+
+    const ping = () =>
+        fetch(`http://127.0.0.1:${port}/mcp`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream',
+                'x-api-key': 'am_dummy',
+            },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }),
+        })
+
+    assert.equal((await ping()).status, 200, 'healthy server admits')
+
+    // Reproduce sustained saturation, which is what the outage actually was:
+    // back-to-back CPU chunks with only a bare yield between them, so the loop is
+    // never idle and every delay sample lands late. One long block would not do
+    // it — the window would still be mostly idle samples and the mean, which is
+    // deliberately the statistic here, would average them away.
+    //
+    // Crucially nothing is in flight while this runs, so an in-flight counter
+    // would read zero and admit everything. The loop-lag trigger is what sees it.
+    const saturateUntil = Date.now() + 3000
+    while (Date.now() < saturateUntil) {
+        const chunkUntil = Date.now() + 600
+        while (Date.now() < chunkUntil) {
+            /* burn a chunk the loop cannot interrupt */
+        }
+        await new Promise((resolve) => setImmediate(resolve))
+    }
+
+    const shedRes = await ping()
+    assert.equal(shedRes.status, 503)
+    assert.ok(Number(shedRes.headers.get('retry-after')) >= 1)
+    const shedBody = await shedRes.json()
+    assert.equal(shedBody.error.code, -32000)
+
+    const health = await (await fetch(`http://127.0.0.1:${port}/health`)).json()
+    assert.ok(health.requests.event_loop_lag_ms > health.requests.max_event_loop_lag_ms)
+    assert.equal(health.requests.in_flight, 0, 'shed happened with nothing in flight')
+
+    // Once the loop is idle again the next sample clears and traffic is admitted
+    // without any intervention — shedding has to be self-healing, or it would
+    // turn a transient spike into a permanent outage.
+    await new Promise((resolve) => setTimeout(resolve, 2400))
+    assert.equal((await ping()).status, 200, 'recovers on its own')
+})
+
+test('the timeout does not fire once the response is already sent', async () => {
+    const res = mockRes()
+    requestTimeout({}, res, () => {})
+
+    res.status(200).json({ ok: true })
+    res.emit('close')
+
+    await new Promise((resolve) => setTimeout(resolve, 1300))
+
+    // Still the handler's own response — the timer must neither overwrite it
+    // nor attempt a second write.
+    assert.equal(res.statusCode, 200)
+    assert.deepEqual(res.body, { ok: true })
+})

--- a/tests/server-admission.test.mjs
+++ b/tests/server-admission.test.mjs
@@ -15,6 +15,7 @@ const { app, admissionControl, requestTimeout } = await import('../packages/serv
 /** Minimal stand-in for an Express response: records what the middleware did. */
 function mockRes() {
     const res = new EventEmitter()
+    res.locals = {}
     res.statusCode = undefined
     res.headers = {}
     res.body = undefined

--- a/tests/server-http.test.mjs
+++ b/tests/server-http.test.mjs
@@ -12,7 +12,7 @@ test('health identifies the build and human MCP navigation redirects before auth
   const { port } = server.address()
 
   const health = await fetch(`http://127.0.0.1:${port}/health`)
-  const { heap, ...healthRest } = await health.json()
+  const { heap, requests, ...healthRest } = await health.json()
   assert.deepEqual(healthRest, {
     status: 'ok',
     clerk_enabled: false,
@@ -23,6 +23,14 @@ test('health identifies the build and human MCP navigation redirects before auth
   assert.ok(heap.used_mb > 0)
   assert.ok(heap.limit_mb >= heap.used_mb)
   assert.ok(heap.rss_mb > 0)
+
+  // Concurrency is the failure mode this server actually has, so /health has to
+  // report it. /health is not part of the MCP pipeline and must never consume a
+  // slot itself, or the probe would distort the number it reports.
+  assert.equal(requests.in_flight, 0)
+  assert.ok(requests.max_in_flight > 0)
+  assert.ok(requests.max_event_loop_lag_ms > 0)
+  assert.equal(typeof requests.shed_total, 'number')
 
   const redirect = await fetch(`http://127.0.0.1:${port}/mcp`, {
     headers: { accept: 'text/html' },

--- a/tests/server-overload-upstream.test.mjs
+++ b/tests/server-overload-upstream.test.mjs
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createServer } from 'node:http'
+
+// A stand-in AgentMail API that accepts the connection and then never answers.
+// This is the shape that matters: StreamableHTTPServerTransport has already
+// written SSE headers by the time a tools/call handler blocks on it, so these
+// requests exercise the headers-already-sent path that a plain `if
+// (res.headersSent) return` timeout silently skips.
+let upstreamLive = 0
+const hangingUpstream = createServer((req) => {
+    // Hold the request open forever, but track whether it is still open so the
+    // tests can assert on real upstream work rather than just our own counter.
+    upstreamLive++
+    req.on('close', () => {
+        upstreamLive--
+    })
+})
+await new Promise((resolve) => hangingUpstream.listen(0, '127.0.0.1', resolve))
+const upstreamPort = hangingUpstream.address().port
+
+process.env.AGENTMAIL_MCP_NO_LISTEN = '1'
+process.env.AGENTMAIL_API_URL = `http://127.0.0.1:${upstreamPort}`
+// Floored at 1000 ms by the implementation.
+process.env.AGENTMAIL_REQUEST_TIMEOUT_MS = '1000'
+// Small enough that two stuck calls fill it, which is the "shedding forever"
+// case being guarded against.
+process.env.AGENTMAIL_MAX_IN_FLIGHT = '2'
+const { app } = await import('../packages/server/build/index.js')
+
+async function withServer(t, fn) {
+    const server = app.listen(0)
+    t.after(() => {
+        server.close()
+    })
+    await new Promise((resolve) => server.once('listening', resolve))
+    return fn(server.address().port)
+}
+
+const health = async (port) => (await fetch(`http://127.0.0.1:${port}/health`)).json()
+
+function callHangingTool(port, signal) {
+    return fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        signal,
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'x-api-key': 'am_dummy',
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: { name: 'list_inboxes', arguments: {} },
+        }),
+    })
+}
+
+/** Drive the call to completion however it ends: reset, error body, or reply. */
+async function settle(promise) {
+    try {
+        const res = await promise
+        await res.text()
+    } catch {
+        /* a destroyed connection surfaces as a fetch/body error, which is the point */
+    }
+}
+
+test('a tool call stuck on a hung upstream still gives its slot back', async (t) => {
+    await withServer(t, async (port) => {
+        const inFlightBefore = (await health(port)).requests.in_flight
+        assert.equal(inFlightBefore, 0)
+
+        const call = settle(callHangingTool(port))
+
+        // The upstream never answers, so this only returns because the timeout
+        // tore the connection down.
+        await call
+
+        // Give the release a tick to land.
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        const after = await health(port)
+        assert.equal(after.requests.in_flight, 0, 'slot returned after the timeout')
+    })
+})
+
+test('hung calls filling the cap do not leave the server shedding permanently', async (t) => {
+    await withServer(t, async (port) => {
+        // Fill every slot with calls that will never complete on their own.
+        const stuck = [settle(callHangingTool(port)), settle(callHangingTool(port))]
+
+        await new Promise((resolve) => setTimeout(resolve, 300))
+        const duringOverload = await fetch(`http://127.0.0.1:${port}/mcp`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream',
+                'x-api-key': 'am_dummy',
+            },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'ping', params: {} }),
+        })
+        await duringOverload.text()
+        assert.equal(duringOverload.status, 503, 'cap is enforced while genuinely full')
+
+        await Promise.all(stuck)
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        // Without the destroy-on-timeout path these slots would never come back
+        // and every later request would 503 for the life of the process.
+        const recovered = await fetch(`http://127.0.0.1:${port}/mcp`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream',
+                'x-api-key': 'am_dummy',
+            },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 10, method: 'ping', params: {} }),
+        })
+        await recovered.text()
+        assert.equal(recovered.status, 200, 'server serves again once hung calls are reaped')
+        assert.equal((await health(port)).requests.in_flight, 0)
+    })
+})
+
+test('a client abort cancels the upstream call instead of orphaning it', async (t) => {
+    await withServer(t, async (port) => {
+        const controller = new AbortController()
+        const call = settle(callHangingTool(port, controller.signal))
+
+        await new Promise((resolve) => setTimeout(resolve, 400))
+        assert.equal((await health(port)).requests.in_flight, 1, 'call is holding a slot')
+        assert.equal(upstreamLive, 1, 'upstream call is open')
+
+        controller.abort()
+        await call
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        // The counter alone is not the property worth asserting: before
+        // cancellation was propagated, in_flight also read 0 here while the
+        // upstream socket stayed open forever. agentmail-toolkit ignores
+        // extra.signal, so the signal has to reach the SDK through the injected
+        // fetch. If it does not, this is the assertion that catches it.
+        assert.equal(upstreamLive, 0, 'upstream call was actually cancelled')
+        assert.equal((await health(port)).requests.in_flight, 0, 'slot returned')
+    })
+})
+
+test('an overloaded server rejects before parsing the body', async (t) => {
+    await withServer(t, async (port) => {
+        // 11 MB, past the 10 MB express.json ceiling. Which status comes back
+        // tells us whether body parsing ran before or after the admission gate.
+        const oversized = JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'ping',
+            params: { pad: 'x'.repeat(11 * 1024 * 1024) },
+        })
+        const post = (body) =>
+            fetch(`http://127.0.0.1:${port}/mcp`, {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream',
+                    'x-api-key': 'am_dummy',
+                },
+                body,
+            })
+
+        // Healthy: the ceiling still applies, so route-scoping the parser did not
+        // quietly drop the 10 MB limit.
+        const healthy = await post(oversized)
+        await healthy.text()
+        assert.equal(healthy.status, 413, 'oversized bodies are still rejected when healthy')
+
+        // Overloaded: every slot held by a stuck call.
+        const stuck = [settle(callHangingTool(port)), settle(callHangingTool(port))]
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        const shed = await post(oversized)
+        await shed.text()
+        // 413 here would mean the 11 MB was parsed before admission could shed
+        // it — precisely the unbounded cost that piles up during a retry storm.
+        assert.equal(shed.status, 503, 'shed before spending anything on the body')
+
+        await Promise.all(stuck)
+    })
+})
+
+test.after(() => {
+    hangingUpstream.close()
+})


### PR DESCRIPTION
## What happened

The Aug 19 outage was a **congestion collapse**, not a capacity or host problem.

A latency blip pushed clients into timeout-and-retry. Retries raised concurrency, concurrency raised the live set and GC cost, the slower process produced more timeouts. Throughput fell from ~200 req/s to under 10 while p50 passed 9s — **at flat demand** — and it never recovered on its own.

Redeploying onto a fresh machine bought **eight minutes** before the retry backlog rebuilt the queue. That is what identifies the loop as self-sustaining rather than the machine as faulty.

## What was ruled out, with measurements

| Hypothesis | Evidence | |
|---|---|---|
| Bad host | Fresh machine collapsed identically in 8 min | ❌ |
| Capacity | Idle machine, same image: **268 req/s** vs 30–60 req/s demand | ❌ |
| Per-request `McpServer` + 26 tools | Benchmarked at **0.31 ms** (~1% of a core at 30 req/s) | ❌ |
| Clerk JWKS fetch per request | kid is in the JWKS; cache TTL 5 min | ❌ |
| Memory / GC death | heap 74–92 MB of 493, RSS flat | ❌ |
| Upstream AgentMail API | `ping` does no upstream I/O and was equally slow | ❌ |
| A single abusive client | Top IP was 11% of traffic, spread across 5 countries | ❌ |

Throughput **collapsed** (200/s → 6.7/s) rather than plateauing. A capacity ceiling plateaus; only a feedback loop collapses.

## The fix

A ceiling, and shed above it. A fast `503` costs no per-request graph and no Clerk verification, keeps the queue short enough that admitted requests stay fast, and `Retry-After` turns a rejection into client backoff instead of the tighter retry loop a timeout provokes.

**Event loop lag is the primary trigger.** An in-flight counter alone would have missed this outage entirely: under saturation a request waits in the kernel and libuv queues long before Express routes it, so in-flight reads near zero while real latency is already seconds. I found this by writing the in-flight cap first and watching a 500-concurrent storm test shed exactly nothing. Measuring the loop catches the backlog wherever it sits.

Lag is sampled as the **mean** over a 1s window, not the max, so a single GC pause cannot shed traffic on a healthy server.

Also included:
- **In-flight cap** as a secondary bound on the live set (each in-flight request pins an `McpServer` + transport + req/res).
- **Request timeout** (504) so slots always come back. Without it the contained-unhandled-rejection path, which deliberately leaves a request unanswered, accumulates until the cap holds only dead requests and every live one is shed — converting a slow outage into a total one.
- **`/health` now reports `in_flight`, `event_loop_lag_ms`, `shed_total`.** The heap block it already had stayed green through the entire outage, because the failure mode is concurrency and nothing was watching it.

All defaults are env-tunable: `AGENTMAIL_MAX_EVENT_LOOP_LAG_MS` (500), `AGENTMAIL_MAX_IN_FLIGHT` (256), `AGENTMAIL_REQUEST_TIMEOUT_MS` (30000), `AGENTMAIL_SHED_RETRY_AFTER_SECONDS` (2).

## Tests

19/19 pass. New coverage includes a test that saturates the event loop and asserts the server sheds **while in-flight is zero** — the case the counter cannot see — and that it recovers on its own without intervention.

```
[admission] shedding: event loop 600 ms behind (limit 300 ms)
[admission] recovered: 0 in flight, 21 ms loop lag, 4 shed so far
```

## Notes for the reviewer

- Two suites fail **identically on clean `main`** in my local env and are untouched by this change: the npm-bridge artifact test (`npm pack --dry-run --json` returns an empty array under pnpm) and `test:python` (uv cannot resolve `agentmail-mcp`). Both should pass in CI's clean environment — worth confirming.
- I deliberately did **not** run the repo's `.prettierrc` over `index.ts`: its `printWidth: 160` does not match how the file is actually formatted (~100), and running it reflows the entire file. The config and the codebase disagree; worth reconciling separately.
- The defaults are picked from measured behaviour (healthy lag is tens of ms; capacity is ~268 req/s) but have not been validated under real production traffic. I'd suggest deploying and watching `event_loop_lag_ms` in `/health` before trusting the 500 ms threshold.