### PR TITLE
Report sockets and descriptors in /health

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -37,6 +37,7 @@ import { SignJWT } from 'jose'
 import crypto from 'node:crypto'
 import v8 from 'node:v8'
 import { monitorEventLoopDelay } from 'node:perf_hooks'
+import fs from 'node:fs'
 import { z } from 'zod'
 
 // ============================================================================
@@ -992,6 +993,73 @@ setInterval(() => {
     loopDelay.reset()
 }, LAG_SAMPLE_INTERVAL_MS).unref()
 
+// ============================================================================
+// Socket & descriptor telemetry
+//
+// The 2026-08-20 follow-up showed the queue is NOT inside Node. On the
+// production machine a GET /mcp — answered 405 by the FIRST handler in the
+// pipeline, before admission, parsing, or auth — took 10-12 s, while event loop
+// lag sat at 20 ms and 0-2 requests were in flight; the idle sibling on the same
+// image answered in 0.13 s. So the wait is between the proxy handing us a
+// connection and our first line of code running. Two things can fill that gap,
+// and only one of them is ours to fix:
+//
+//   - Node cannot accept. When open descriptors hit the ulimit, accept() fails
+//     with EMFILE; libuv then accepts-and-closes to drain the backlog, the proxy
+//     sees resets and retries, and every request waits while the loop stays
+//     idle. open_fds approaching max_fds is the tell, and the fix is ours:
+//     hold fewer connections (keep-alive and header timeouts, maxConnections).
+//   - The proxy is queueing before it connects. Then connections and fds stay
+//     low here while latency climbs, and the lever is proxy concurrency and
+//     horizontal scale — not anything in this process.
+//
+// /health reports both so the next episode answers this in one request.
+// ============================================================================
+
+let openConnections = 0
+let acceptedTotal = 0
+let clientErrorsTotal = 0
+
+function readOpenFds(): number | undefined {
+    try {
+        return fs.readdirSync('/proc/self/fd').length
+    } catch {
+        return undefined
+    }
+}
+
+function readMaxFds(): number | 'unlimited' | undefined {
+    try {
+        // "Max open files            1024                 1048576              files"
+        const line = fs
+            .readFileSync('/proc/self/limits', 'utf8')
+            .split('\n')
+            .find((l) => l.startsWith('Max open files'))
+        const m = line?.match(/Max open files\s+(\d+|unlimited)/)
+        if (!m) return undefined
+        return m[1] === 'unlimited' ? 'unlimited' : parseInt(m[1]!, 10)
+    } catch {
+        return undefined
+    }
+}
+
+// The SOFT limit is what accept() enforces.
+const MAX_FDS = readMaxFds()
+// Transition-logged, same as shedding: at exhaustion every accept fails.
+let fdPressure = false
+function sampleDescriptors() {
+    const open = readOpenFds()
+    if (open === undefined || typeof MAX_FDS !== 'number') return
+    const pressured = open > MAX_FDS * 0.8
+    if (pressured && !fdPressure) {
+        fdPressure = true
+        console.warn(`[fds] pressure: ${open} open of ${MAX_FDS} (soft limit), ${openConnections} connections`)
+    } else if (!pressured && fdPressure) {
+        fdPressure = false
+        console.warn(`[fds] recovered: ${open} open of ${MAX_FDS}`)
+    }
+}
+
 /**
  * One admitted request's hold on the in-flight cap. `ownedByHandler` transfers
  * responsibility for releasing it from the connection lifecycle to mcpHandler,
@@ -1234,6 +1302,17 @@ app.get('/health', (_req, res) => {
             event_loop_lag_ms: Math.round(recentLagMs),
             max_event_loop_lag_ms: MAX_EVENT_LOOP_LAG_MS,
         },
+        // Where the queue is. Low in_flight + low lag + climbing latency means
+        // the wait is upstream of the first middleware. If open_fds is near
+        // max_fds the process cannot accept and the fix is ours; if both are
+        // low the proxy is queueing before it connects and the fix is not.
+        sockets: {
+            open_connections: openConnections,
+            accepted_total: acceptedTotal,
+            client_errors_total: clientErrorsTotal,
+            open_fds: readOpenFds() ?? null,
+            max_fds: MAX_FDS ?? null,
+        },
     })
 })
 
@@ -1318,7 +1397,8 @@ process.on('unhandledRejection', (reason) => {
     console.error('[fatal-contained] unhandled promise rejection:', reason)
 })
 
-if (process.env.AGENTMAIL_MCP_NO_LISTEN !== '1') app.listen(PORT, () => {
+if (process.env.AGENTMAIL_MCP_NO_LISTEN !== '1') {
+    const server = app.listen(PORT, () => {
     console.log(`AgentMail MCP server running on port ${PORT}`)
     console.log(`MCP endpoints: http://localhost:${PORT}/ and http://localhost:${PORT}/mcp`)
     console.log(`Clerk OAuth: ${CLERK_ENABLED ? 'enabled' : 'disabled (no CLERK_* env vars)'}`)
@@ -1331,5 +1411,22 @@ if (process.env.AGENTMAIL_MCP_NO_LISTEN !== '1') app.listen(PORT, () => {
     console.log(maskEnvVar('AGENTMAIL_API_URL'))
     console.log(maskEnvVar('AGENTMAIL_API_KEY'))
     console.log(maskEnvVar('MCP_PUBLIC_URL'))
+    console.log(`Max open files (soft): ${MAX_FDS ?? 'unknown'}`)
     console.log('--------------------------')
-})
+    })
+
+    server.on('connection', () => {
+        acceptedTotal++
+    })
+    // Parse errors and socket-level timeouts surface here, not in Express. A
+    // climbing count means sockets are being torn down abnormally.
+    server.on('clientError', () => {
+        clientErrorsTotal++
+    })
+    setInterval(() => {
+        server.getConnections((err, count) => {
+            if (!err) openConnections = count
+        })
+        sampleDescriptors()
+    }, 1000).unref()
+}

--- a/tests/server-http.test.mjs
+++ b/tests/server-http.test.mjs
@@ -12,7 +12,7 @@ test('health identifies the build and human MCP navigation redirects before auth
   const { port } = server.address()
 
   const health = await fetch(`http://127.0.0.1:${port}/health`)
-  const { heap, requests, ...healthRest } = await health.json()
+  const { heap, requests, sockets, ...healthRest } = await health.json()
   assert.deepEqual(healthRest, {
     status: 'ok',
     clerk_enabled: false,
@@ -31,6 +31,15 @@ test('health identifies the build and human MCP navigation redirects before auth
   assert.ok(requests.max_in_flight > 0)
   assert.ok(requests.max_event_loop_lag_ms > 0)
   assert.equal(typeof requests.shed_total, 'number')
+
+  // Socket telemetry is present even when the process is not listening (tests
+  // import the app without listening), so counters read zero. open_fds and
+  // max_fds come from /proc and are null where it does not exist (macOS).
+  assert.equal(typeof sockets.open_connections, 'number')
+  assert.equal(typeof sockets.accepted_total, 'number')
+  assert.equal(typeof sockets.client_errors_total, 'number')
+  assert.ok('open_fds' in sockets)
+  assert.ok('max_fds' in sockets)
 
   const redirect = await fetch(`http://127.0.0.1:${port}/mcp`, {
     headers: { accept: 'text/html' },


### PR DESCRIPTION
Diagnostics only — **no behaviour change**. Adds a `sockets` block to `/health`:

```
open_connections, accepted_total, client_errors_total, open_fds, max_fds
```

plus the soft descriptor limit at boot and a transition-logged warning above 80% of it.

## Why

After #43 deployed as #117, the server ran clean for ~13 min then degraded again (gw p50 4–9 s). The counters #43 added answered the question it left open — and the answer was the bad branch: **latency climbed while `event_loop_lag_ms` stayed at 20 ms and `shed_total` stayed 0.** The gate never fired because the queue is not inside Node.

Decisive measurement: `GET /mcp` → 405 from `statelessMethodGuard`, the **first** handler in the pipeline, took **10.0 s / 12.4 s** on the production machine (TCP connect 0.010 s) while the idle sibling on the same image answered in **0.13 s**. The wait sits between the proxy handing us a connection and our first line of code.

Two hypotheses fit, and only one is ours to fix:

| | mechanism | signal |
|---|---|---|
| **descriptor exhaustion** (ours) | open sockets reach the ulimit → `accept()` EMFILE → libuv accepts-and-closes → proxy retries → requests wait, loop idle | `open_fds` → `max_fds` |
| proxy queueing (Manufact) | proxy queues before it connects to us | connections and fds low, latency high |

The first also explains why a fresh machine is fine for ~10 min (descriptors accumulate) and an idle sibling is fine forever. This PR exists to tell them apart with data rather than a third guess.

Two further checks ruled out in-process causes on the way here: a 20-sample latency distribution is continuous (0.1→18 s), not clustered at SYN-retry intervals; and the AgentMail SDK uses the global `fetch`, so per-tool-call client construction does not leak connection pools.

## What to do with the numbers

Deploy, wait ~15 min for the degradation to reappear, read `/health` on the `.fly.dev` host. Either `open_fds` is near `max_fds` — then the fix is connection hygiene in this process (`keepAliveTimeout`, `headersTimeout`, `maxConnections`) and possibly raising the limit in the start command — or both are low, and the lever is Fly proxy concurrency + horizontal scale on the Manufact side.