### PR TITLE
Report CPU steal in /health

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -87,3 +87,12 @@ transition and `sockets.accepted_total` / `tcp.port.acceptQueue` show the pressu
 If overflows persist at a raised backlog, the burst rate exceeds what one machine can
 accept and the levers are reducing per-request work on the accept path and horizontal
 scale.
+
+## CPU steal
+
+`/health` reports `cpu.steal_pct` — the share of the last second the hypervisor
+refused to schedule this vCPU, from `/proc/stat`. On a shared-CPU machine the
+quota freeze is invisible to the process and its logs; steal is the one number
+that separates "our code is slow" from "the host is withholding CPU". Sustained
+steal above 50% logs `[cpu] steal pressure` and means the machine size, not the
+code, is the constraint.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1252,6 +1252,77 @@ function kernelTcpSnapshot() {
     }
 }
 
+// ============================================================================
+// CPU steal telemetry
+//
+// With the backlog fixed (#46) the collapse stopped (ListenOverflows frozen)
+// but the accept queue still sits hundreds deep and drains at ~46/s while the
+// event loop shows a sustained 88-120 ms lag at only ~17 req/s of mostly-ping
+// traffic. An idle machine on the identical image runs at 20 ms. Nothing in
+// the process accounts for that floor.
+//
+// The remaining suspect is the host: on a shared-CPU machine the hypervisor
+// enforces a quota (Fly shared-cpu-1x: ~6.25% of a core, granted 5 ms per
+// 80 ms period) and FREEZES the vCPU for the rest of the period once it is
+// spent. That freeze is invisible to the app and to its logs, but the kernel
+// counts it: the `steal` column of /proc/stat is time the guest was runnable
+// and the hypervisor did not schedule it. Steal at ~70-90% during an episode
+// confirms quota throttling; steal near zero refutes it. Either answer is
+// decisive, and this is the only place we can read it without access to the
+// provider's Fly org metrics.
+// ============================================================================
+
+type CpuTimes = { total: number; idle: number; iowait: number; steal: number }
+
+function readCpuTimes(): CpuTimes | undefined {
+    const text = readProc('/proc/stat')
+    if (!text) return undefined
+    const line = text.split('\n')[0]
+    if (!line?.startsWith('cpu ')) return undefined
+    // cpu  user nice system idle iowait irq softirq steal guest guest_nice
+    const f = line.trim().split(/\s+/).slice(1).map(Number)
+    const [user = 0, nice = 0, system = 0, idle = 0, iowait = 0, irq = 0, softirq = 0, steal = 0] = f
+    return { total: user + nice + system + idle + iowait + irq + softirq + steal, idle, iowait, steal }
+}
+
+let prevCpuTimes: CpuTimes | undefined
+const cpuPct: { steal_pct: number | null; busy_pct: number | null; idle_pct: number | null } = {
+    steal_pct: null,
+    busy_pct: null,
+    idle_pct: null,
+}
+// Transition-logged like the fd and accept-queue warnings: sustained steal is
+// the signal, and at 1 Hz sampling per-tick logging would flood under exactly
+// the condition being diagnosed.
+let stealPressure = false
+
+function sampleCpu() {
+    const cur = readCpuTimes()
+    if (!cur) return
+    if (prevCpuTimes) {
+        const dTotal = cur.total - prevCpuTimes.total
+        if (dTotal > 0) {
+            const steal = (100 * (cur.steal - prevCpuTimes.steal)) / dTotal
+            const idle = (100 * (cur.idle - prevCpuTimes.idle)) / dTotal
+            const iowait = (100 * (cur.iowait - prevCpuTimes.iowait)) / dTotal
+            cpuPct.steal_pct = Math.round(steal)
+            cpuPct.idle_pct = Math.round(idle)
+            cpuPct.busy_pct = Math.round(Math.max(0, 100 - idle - iowait - steal))
+            const pressured = steal > 50
+            if (pressured && !stealPressure) {
+                stealPressure = true
+                console.warn(
+                    `[cpu] steal pressure: hypervisor withheld ${Math.round(steal)}% of CPU this interval — quota throttling`
+                )
+            } else if (!pressured && stealPressure) {
+                stealPressure = false
+                console.warn(`[cpu] steal recovered: ${Math.round(steal)}%`)
+            }
+        }
+    }
+    prevCpuTimes = cur
+}
+
 /**
  * One admitted request's hold on the in-flight cap. `ownedByHandler` transfers
  * responsibility for releasing it from the connection lifecycle to mcpHandler,
@@ -1506,6 +1577,10 @@ app.get('/health', (_req, res) => {
             max_fds: MAX_FDS ?? null,
         },
         tcp: kernelTcpSnapshot(),
+        // Guest CPU accounting over the last ~1s sample. steal_pct is time the
+        // hypervisor refused to schedule this vCPU — the one number that
+        // separates "our code is slow" from "the host is withholding CPU".
+        cpu: cpuPct,
     })
 })
 
@@ -1643,6 +1718,7 @@ export function startListening(port: number = PORT) {
         })
         sampleDescriptors()
         sampleAcceptQueue()
+        sampleCpu()
     }, 1000)
     sampler.unref()
     server.on('close', () => clearInterval(sampler))

--- a/tests/server-http.test.mjs
+++ b/tests/server-http.test.mjs
@@ -12,7 +12,7 @@ test('health identifies the build and human MCP navigation redirects before auth
   const { port } = server.address()
 
   const health = await fetch(`http://127.0.0.1:${port}/health`)
-  const { heap, requests, sockets, tcp, ...healthRest } = await health.json()
+  const { heap, requests, sockets, tcp, cpu, ...healthRest } = await health.json()
   assert.deepEqual(healthRest, {
     status: 'ok',
     clerk_enabled: false,
@@ -45,6 +45,13 @@ test('health identifies the build and human MCP navigation redirects before auth
   // (macOS); the shape is always present so dashboards can rely on it.
   for (const k of ['sockstat', 'port', 'tcp', 'tcp_ext', 'kernel', 'connection_header', 'http_version']) {
     assert.ok(k in tcp, `tcp.${k}`)
+  }
+
+  // CPU steal comes from /proc/stat deltas computed by the 1 Hz sampler, which
+  // only runs when listening; here (and on macOS, where /proc is absent) the
+  // values are null but the shape is always present.
+  for (const k of ['steal_pct', 'busy_pct', 'idle_pct']) {
+    assert.ok(k in cpu, `cpu.${k}`)
   }
 
   const redirect = await fetch(`http://127.0.0.1:${port}/mcp`, {


### PR DESCRIPTION
Diagnostics only — **no behaviour change**. Adds `cpu.steal_pct / busy_pct / idle_pct` to `/health` (from `/proc/stat` deltas, sampled at 1 Hz) and a transition-logged `[cpu] steal pressure` warning above 50%.

## Why

#46 stopped the congestion collapse — `ListenOverflows` is frozen where it previously climbed by thousands — but the user-visible symptom remains: the accept queue sits hundreds deep (spikes to 1726 against the 2048 backlog), drains at only ~46/s, and the event loop shows a **sustained 88–120 ms lag at ~17 req/s of mostly-`ping` traffic**. An idle machine on the identical image runs at 20 ms. Heap is healthy, in-flight is 0–4, and the `/proc` telemetry from #44/#45 already exonerated descriptors, TIME_WAIT, and the sampling itself.

The remaining suspect is the **host's CPU quota**. The arithmetic fits exactly:

- this image serves ~268 req/s at full burst ⇒ ~3.7 ms CPU/request
- a shared-cpu machine's sustained quota is ~6.25% of a core (5 ms per 80 ms period, frozen for the rest of the period once spent) ⇒ 62.5 ms/s ÷ 3.7 ms ≈ **17 req/s — the observed plateau**
- a sustained 88–120 ms loop lag is the fingerprint of the 80 ms quota period, not of any code path
- "redeploy helps for ~10 min, then degrades" matches the burst-CPU balance draining, which we previously attributed to retry backlog

The quota freeze is invisible to the process and to its logs, but the kernel counts it: the `steal` column of `/proc/stat` is time the guest was runnable and the hypervisor did not schedule it. We cannot see the provider's Fly metrics (`fly_instance_cpu_throttle`, burst balance); `/proc/stat` is the same fact readable from inside.

## Decision tree once deployed

- **`steal_pct` ~70–90% during an episode** → quota throttling confirmed. The fix is a machine with dedicated CPU + ≥2 machines (provider side; their API exposes no size knob), plus a `ping` fast-path on ours to cut per-request CPU.
- **`steal_pct` ≈ 0 while lag is 88–120 ms** → the throttling theory is wrong too, and the next build instruments accept-batch size and per-phase timings inside the process.

Same procedure as #44/#45: merge, deploy, read `/health` on the `.fly.dev` host during degradation (~10–15 min after start).