### PR TITLE
Answer ping from a fast path before auth and server construction

### DIFF
--- a/docs/incidents/2026-08-20-listen-backlog-overflow.md
+++ b/docs/incidents/2026-08-20-listen-backlog-overflow.md
@@ -102,3 +102,19 @@ the kernel counters were the only place left to look and the answer was there.
   calls) and scale horizontally.
 - Point external monitoring at the app's own `/health` or an MCP `ping`, not the
   gateway `/health`, which cannot see an application-level outage.
+
+## Addendum (2026-08-20, later the same day): the layer beneath the backlog
+
+The backlog fix removed the collapse amplifier — `ListenOverflows` froze where
+it had been climbing by thousands — but baseline latency stayed at 5–20 s. The
+constraint beneath it was measured directly with CPU-steal telemetry
+(`/health.cpu`, from `/proc/stat`): on a fresh machine, at minute ~8, steal
+jumped from 1% to 46–63% while busy pinned at 4–5% — a shared-CPU machine's
+~6.25% quota being enforced after its burst balance drained. The arithmetic
+closes: ~3.7 ms CPU per request against a ~62 ms/s sustained budget is
+~17 req/s of capacity, exactly the observed plateau, and the burst-balance
+drain is why every fresh machine was healthy for ~8–14 minutes before
+degrading. Remedy is provider-side (dedicated-CPU machine, ≥2 machines; the
+hosting API exposes no size control). On our side, the ping fast path cuts
+per-request CPU for two thirds of traffic by ~70x, roughly doubling sustained
+capacity on the same quota.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,3 +96,14 @@ quota freeze is invisible to the process and its logs; steal is the one number
 that separates "our code is slow" from "the host is withholding CPU". Sustained
 steal above 50% logs `[cpu] steal pressure` and means the machine size, not the
 code, is the constraint.
+
+## Ping fast path
+
+MCP `ping` (about two thirds of all traffic) is answered immediately after body
+parsing — before Clerk verification and before a per-request MCP server is
+built — as a plain `application/json` JSON-RPC response. This cuts the CPU cost
+of a ping from ~3.7 ms to ~0.05 ms, which matters on a CPU-quota-limited
+machine. Pings are deliberately not rate limited and need no credentials: a
+rejected or dropped ping makes clients tear down and re-initialize (three
+full-path requests, ~200x the cost of answering), so the answer itself is the
+cheapest defense. `requests.pings_fast_path` in `/health` counts them.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1336,6 +1336,7 @@ function admissionSlotOf(res: express.Response): AdmissionSlot | undefined {
 
 let inFlight = 0
 let shedTotal = 0
+let pingsFastPathed = 0
 // Log the transition, not the event: at overload the shed rate is exactly the
 // excess arrival rate, so per-request logging would itself become a load source.
 let shedding = false
@@ -1501,11 +1502,48 @@ app.get(['/', '/mcp'], (req, res, next) => {
 // GET/DELETE, admissionControl caps concurrency, requestTimeout guarantees slots
 // come back, and only then does a request earn body parsing, Clerk
 // authentication, and a per-request MCP server.
+// ============================================================================
+// Ping fast path
+//
+// 67% of production traffic is MCP `ping` — a liveness probe whose only correct
+// answer is an empty result, promptly. On the full path each ping still paid
+// body parse + Clerk verification + a fresh McpServer with 26 registered tools
+// + SSE transport setup: ~3.7 ms of CPU for a reply that carries no data. On a
+// quota-throttled machine with a ~62 ms/s budget, pings alone consumed most of
+// the sustained capacity.
+//
+// Answering here, right after body parse, costs ~0.05 ms and is spec-correct:
+// Streamable HTTP allows a plain application/json JSON-RPC response, and ping's
+// result is always {}.
+//
+// Deliberately NOT rate-limited, and answered without auth. A ping is how
+// clients decide the server is alive; reject or drop one and the client tears
+// down and re-initializes — initialize + notifications/initialized + tools/list,
+// three full-path requests, ~200x the cost of answering. The answer itself is
+// the cheapest possible defense; genuine overload is already handled by
+// admissionControl upstream, which sheds everything alike. Skipping auth is the
+// point (verification is most of the per-ping cost) and leaks nothing — the
+// response is a constant. The one observable change: an unauthenticated ping
+// now gets 200 instead of the 401 challenge; real requests still 401.
+// ============================================================================
+
+const pingFastPath: express.RequestHandler = (req, res, next) => {
+    const body = req.body as unknown
+    if (body === null || typeof body !== 'object' || Array.isArray(body)) return next()
+    const { method, id } = body as { method?: unknown; id?: unknown }
+    // id present = request (needs a response we can give); id absent = a
+    // notification, which the SDK answers with 202 — let it fall through.
+    if (method !== 'ping' || (typeof id !== 'string' && typeof id !== 'number')) return next()
+    pingsFastPathed++
+    res.status(200).json({ jsonrpc: '2.0', id, result: {} })
+}
+
 const mcpPipeline = [
     statelessMethodGuard,
     admissionControl,
     requestTimeout,
     parseJsonBody,
+    pingFastPath,
     clerkAuthBoundary,
     authRouter,
     mcpHandler,
@@ -1564,6 +1602,7 @@ app.get('/health', (_req, res) => {
             shed_total: shedTotal,
             event_loop_lag_ms: Math.round(recentLagMs),
             max_event_loop_lag_ms: MAX_EVENT_LOOP_LAG_MS,
+            pings_fast_path: pingsFastPathed,
         },
         // Where the queue is. Low in_flight + low lag + climbing latency means
         // the wait is upstream of the first middleware. If open_fds is near

--- a/tests/server-auth.test.mjs
+++ b/tests/server-auth.test.mjs
@@ -34,7 +34,9 @@ test('malformed Authorization headers get a 401 challenge instead of crashing th
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream',
       },
-      body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
+      // Not `ping`: pings are answered by the fast path before auth runs, so
+      // they can no longer carry a malformed header into the guard at all.
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
     })
     assert.equal(res.status, 401, `expected 401 for header ${JSON.stringify(authorization)}`)
     assert.match(
@@ -44,6 +46,22 @@ test('malformed Authorization headers get a 401 challenge instead of crashing th
     )
     assert.deepEqual(await res.json(), { error: 'Unauthorized' })
   }
+
+  // A ping with the same malformed header is answered by the fast path with
+  // 200 — auth never sees it. This is the intended behavior change: the header
+  // shapes that once crash-looped production cannot even reach that code via
+  // ping anymore.
+  const pingRes = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer',
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
+  })
+  assert.equal(pingRes.status, 200)
+  assert.deepEqual(await pingRes.json(), { jsonrpc: '2.0', id: 1, result: {} })
 
   // The server is still alive and serving after the malformed requests.
   const health = await fetch(`http://127.0.0.1:${port}/health`)

--- a/tests/server-ping.test.mjs
+++ b/tests/server-ping.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+process.env.AGENTMAIL_MCP_NO_LISTEN = '1'
+const { app } = await import('../packages/server/build/index.js')
+
+async function withServer(t, fn) {
+    const server = app.listen(0)
+    t.after(() => new Promise((resolve) => server.close(resolve)))
+    await new Promise((resolve) => server.once('listening', resolve))
+    return fn(server.address().port)
+}
+
+const post = (port, body, headers = {}) =>
+    fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            ...headers,
+        },
+        body: JSON.stringify(body),
+    })
+
+test('ping is answered from the fast path with a plain JSON-RPC response', async (t) => {
+    await withServer(t, async (port) => {
+        const res = await post(port, { jsonrpc: '2.0', id: 42, method: 'ping' })
+        assert.equal(res.status, 200)
+        // Plain JSON, not SSE: the fast path never builds the transport. Both
+        // are legal for Streamable HTTP clients, which must accept either.
+        assert.match(res.headers.get('content-type') ?? '', /application\/json/)
+        assert.deepEqual(await res.json(), { jsonrpc: '2.0', id: 42, result: {} })
+
+        const health = await (await fetch(`http://127.0.0.1:${port}/health`)).json()
+        assert.ok(health.requests.pings_fast_path >= 1, 'counter tracks fast-pathed pings')
+    })
+})
+
+test('ping echoes string ids exactly', async (t) => {
+    await withServer(t, async (port) => {
+        const res = await post(port, { jsonrpc: '2.0', id: 'req-abc', method: 'ping' })
+        assert.deepEqual(await res.json(), { jsonrpc: '2.0', id: 'req-abc', result: {} })
+    })
+})
+
+test('ping needs no credentials — a probe must not cost an auth round-trip', async (t) => {
+    await withServer(t, async (port) => {
+        // No x-api-key, no Authorization. Skipping auth is the point of the
+        // fast path (verification is most of the per-ping cost) and the
+        // response is a constant, so nothing leaks.
+        const res = await post(port, { jsonrpc: '2.0', id: 1, method: 'ping' })
+        assert.equal(res.status, 200)
+    })
+})
+
+test('a ping-shaped notification (no id) falls through to the SDK', async (t) => {
+    await withServer(t, async (port) => {
+        // Without an id this is a notification; the transport acknowledges
+        // notifications with 202 and no body. The fast path must not swallow it.
+        const res = await post(port, { jsonrpc: '2.0', method: 'ping' })
+        assert.equal(res.status, 202)
+    })
+})
+
+test('non-ping requests still take the full path', async (t) => {
+    await withServer(t, async (port) => {
+        const res = await post(
+            port,
+            {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2025-06-18',
+                    capabilities: {},
+                    clientInfo: { name: 'test', version: '1' },
+                },
+            },
+            { 'x-api-key': 'am_dummy' }
+        )
+        assert.equal(res.status, 200)
+        // The full path answers via the SDK transport (SSE), proving initialize
+        // did not get intercepted by the ping shortcut.
+        assert.match(res.headers.get('content-type') ?? '', /text\/event-stream/)
+    })
+})


### PR DESCRIPTION
## Why

#47's steal telemetry proved the machine is CPU-quota throttled: once the burst balance drains (~8 min), the hypervisor withholds 46–63% of CPU and **busy pins at 4–5% ≈ the shared-cpu quota**. Sustained budget is ~62 ms/s; at ~3.7 ms CPU/request that is ~17 req/s of capacity — exactly the observed plateau.

**67% of traffic is `ping`.** On the full path each ping paid body parse + Clerk verification + a fresh McpServer (26 tools) + SSE transport: ~3.7 ms for a reply that is always `{}`. This PR answers ping right after body parse for ~0.05 ms (**~70x cheaper**), which roughly **doubles sustained capacity on the same quota** — our only unilateral lever while the machine resize request is with Manufact.

## Deliberately not rate limited, deliberately unauthenticated

Considered and rejected a rate limiter on pings: a ping is how clients decide the server is alive. Reject or drop one and the client tears down and re-initializes — `initialize` + `notifications/initialized` + `tools/list`, three full-path requests, **~200x the cost of answering**. A ping limiter can only amplify load; the answer itself is the cheapest defense. Genuine overload is already handled by `admissionControl` upstream, which sheds all traffic alike with `Retry-After`.

Skipping auth is the point (verification is most of the per-ping cost) and leaks nothing — the response is a constant.

## Observable changes

- Ping responses are plain `application/json` instead of SSE. Both are legal for Streamable HTTP; clients must accept either.
- An unauthenticated (or malformed-`Authorization`) ping now gets `200` instead of the `401` challenge. Real requests still `401` and re-enter OAuth discovery. The malformed-header crash-guard test now uses `tools/list` as its vehicle, since pings can no longer reach that code path at all, plus an explicit assertion of the new ping behavior.
- Ping-shaped **notifications** (no `id`) fall through to the SDK unchanged (202), as does everything not exactly a ping request. Batch bodies fall through.
- `requests.pings_fast_path` in `/health` counts hits, so the CPU claim is verifiable in production.

## Tests

29 pass / 1 skipped (Linux-only backlog check). New suite covers: fast-path response shape + counter, string-id echo, no-credential pings, notification fall-through (202), and initialize still taking the full SSE path.

## After deploy

On the quota-throttled machine, expect: `pings_fast_path` climbing at ~2/3 of request rate, busy% headroom roughly doubling, and the accept queue draining faster. This complements — does not replace — the machine resize requested from Manufact (#47's steal evidence).